### PR TITLE
Use a simpler but equivalent `.travis.yml` file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,9 @@ before_script:
 - if [[ -e ~/.local/bin ]]; then export PATH=~/.local/bin:$PATH; fi
 
 script:
-- |
-  travis-cargo build &&
-  travis-cargo test &&
-  travis-cargo bench
+-  travis-cargo build
+-  travis-cargo test
+-  travis-cargo bench
 
 after_success:
 - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_RUST_VERSION" == "nightly" ]]; then travis-cargo coveralls --no-sudo --verify; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ before_script:
 
 script:
 - |
-  cargo build &&
-  cargo test &&
-  cargo bench
+  travis-cargo build &&
+  travis-cargo test &&
+  travis-cargo bench
 
 after_success:
 - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_RUST_VERSION" == "nightly" ]]; then travis-cargo coveralls --no-sudo --verify; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
-sudo: false
-
 language: rust
 cache: cargo
 
 os:
 - linux
 - osx
-
-osx_image: xcode7.1
 
 rust:
 - nightly
@@ -22,21 +18,15 @@ addons:
     - libdw-dev
     - binutils-dev
 
-before_install:
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python || true; fi
-
 before_script:
 - pip install -v 'travis-cargo<0.2' --user
-- if [[ -e ~/Library/Python/2.7/bin ]]; then export PATH=~/Library/Python/2.7/bin:$PATH; fi
 - if [[ -e ~/.local/bin ]]; then export PATH=~/.local/bin:$PATH; fi
-- echo PATH is $PATH
 
 script:
 - |
-  travis-cargo build &&
-  travis-cargo test &&
-  travis-cargo bench
+  cargo build &&
+  cargo test &&
+  cargo bench
 
 after_success:
 - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_RUST_VERSION" == "nightly" ]]; then travis-cargo coveralls --no-sudo --verify; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ addons:
 
 before_script:
 - pip install -v 'travis-cargo<0.2' --user
+- if [[ -e ~/Library/Python/2.7/bin ]]; then export PATH=~/Library/Python/2.7/bin:$PATH; fi
 - if [[ -e ~/.local/bin ]]; then export PATH=~/.local/bin:$PATH; fi
 
 script:


### PR DESCRIPTION
The current `.travis.yml` file contains a number of unnecessary elements that this PR removes. This decreases overall build time, as well as getting rid of unneeded complexity.

In particular:
 - `sudo: false` is the default for all new Travis builds,
 - `osx_image: xcode7.1` is no longer valid -- the default is `xcode7.3`, and all lower versions are automatically bumped.
 - `brew update` and `brew install python` on osx: not needed, as `python2.7` is always installed on Travis