### PR TITLE
Add support for symbol demangling in addr2line binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ memmap = "0.5.0"
 object = "0.1.0"
 owning_ref = { git = "https://github.com/Kimundi/owning-ref-rs" } # need OwningHandle
 error-chain = "0.7.1"
+rustc-demangle = "0.1.3"
 
 [dev-dependencies]
 glob = "0.2"


### PR DESCRIPTION
This PR adds support for symbol demangling in the `addr2line` binary when run with the `-C` flag (similar to GNU binutils `addr2line`). It uses @alexcrichton's [rustc-demangle](https://github.com/alexcrichton/rustc-demangle) crate, which provides demangling for Rust's standard mangling, but which probably catches various mangles performed by other compilers too.

Will rebase once #8 and #9 have been merged.