### PR TITLE
Add benchmarking script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+*.png

--- a/bench.plot.r
+++ b/bench.plot.r
@@ -1,0 +1,17 @@
+v <- read.table(file("stdin"))
+t <- data.frame(prog=v[,1], funcs=(v[,2]=="func"), time=v[,3], mem=v[,4])
+
+library(ggplot2)
+p <- ggplot(data=t, aes(x=prog, y=time, fill=prog))
+p <- p + geom_bar(stat = "identity")
+p <- p + facet_wrap(~ funcs)
+p <- p + theme(axis.title.x=element_blank(), axis.text.x=element_blank(), axis.ticks.x=element_blank())
+p <- p + ylab("time (s)") + ggtitle("Runtime for benchmark variants")
+ggsave('time.png',plot=p,width=10,height=6)
+
+p <- ggplot(data=t, aes(x=prog, y=mem, fill=prog))
+p <- p + geom_bar(stat = "identity")
+p <- p + facet_wrap(~ funcs)
+p <- p + theme(axis.title.x=element_blank(), axis.text.x=element_blank(), axis.ticks.x=element_blank())
+p <- p + ylab("memory (B)") + ggtitle("Memory use for benchmark variants")
+ggsave('memory.png',plot=p,width=10,height=6)

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+if [[ $# -le 1 ]]; then
+	echo "Usage: $0 <executable> [<addresses>] REFS..."
+	exit 1
+fi
+target="$1"
+shift
+
+addresses=""
+if [[ -e "$1" ]]; then
+	addresses="$1"
+	shift
+fi
+
+# path to "us"
+# readlink -f, but more portable:
+dirname=$(perl -e 'use Cwd "abs_path";print abs_path(shift)' "$(dirname "$0")")
+
+# compile all refs
+pushd "$dirname" > /dev/null
+if ! git diff-index --quiet HEAD --; then
+	echo "Refusing to overwrite outstanding git changes"
+	exit 2
+fi
+current=$(git symbolic-ref --short HEAD)
+for ref in "$@"; do
+	echo "==> Compiling $ref"
+	git checkout -q "$ref"
+	commit=$(git rev-parse HEAD)
+	fn="target/release/addr2line-$commit"
+	if [[ ! -e "$fn" ]]; then
+		cargo build --release
+		cp target/release/addr2line "$fn"
+	fi
+	if [[ "$ref" != "$commit" ]]; then
+		ln -sfn "addr2line-$commit" target/release/addr2line-"$ref"
+	fi
+done
+git checkout -q "$current"
+popd > /dev/null
+
+# get us some addresses to look up
+if [[ -z "$addresses" ]]; then
+	echo "==> Looking for benchmarking addresses (this may take a while)"
+	addresses=$(mktemp tmp.XXXXXXXXXX)
+	objdump -C -x --disassemble -l "$target" \
+		| grep -P '0[048]:' \
+		| awk '{print $1}' \
+		| sed 's/:$//' \
+		> "$addresses"
+	echo "  -> Addresses stored in $addresses; you should re-use it next time"
+fi
+
+run() {
+	func="$1"
+	name="$2"
+	cmd="$3"
+	args="$4"
+	printf "%s\t%s\t" "$name" "$func"
+	/usr/bin/time -f '%e\t%M' "$cmd" $args -e "$target" < "$addresses" 2>&1 >/dev/null
+}
+
+log=$(mktemp tmp.XXXXXXXXXX)
+
+# run without functions
+echo "==> Benchmarking"
+run nofunc binutils addr2line > "$log"
+for ref in "$@"; do
+	run nofunc "$ref" "$dirname/target/release/addr2line-$ref" >> "$log"
+done
+
+# run with functions
+echo "==> Benchmarking with -f"
+run func binutils addr2line -f >> "$log"
+for ref in "$@"; do
+	run func "$ref" "$dirname/target/release/addr2line-$ref" -f >> "$log"
+done
+
+echo "==> Plotting"
+Rscript --no-readline --no-restore --no-save "$dirname/bench.plot.r" < "$log"
+
+echo "==> Cleaning up"
+rm "$log"


### PR DESCRIPTION
Following @fitzgen's request in #18, here are the scripts I used to generate the plots in #14 and #19. I cleaned them up a fair bit, though they could probably still use some more cleaning. You will need `R` installed, along with the `ggplot2` package.

Invoke as
```console
$ ./benchmark.sh path/to/executable master somebranch 7fdd85ef
```
or if you already have a bunch of addresses in `addresses.txt`:
```console
$ ./benchmark.sh path/to/executable addresses.txt master somebranch 7fdd85ef
```

Results are in `./time.png` and `./memory.png`.