### PR TITLE
Add benchmark comparison against other addr2line implementations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 Cargo.lock
 *.png
+tmp.*

--- a/bench.plot.r
+++ b/bench.plot.r
@@ -1,17 +1,21 @@
 v <- read.table(file("stdin"))
 t <- data.frame(prog=v[,1], funcs=(v[,2]=="func"), time=v[,3], mem=v[,4])
 
+t$funcs[t$funcs == TRUE] <- "With functions"
+t$funcs[t$funcs == FALSE] <- "File/line only"
+t$mem = t$mem / 1024.0
+
 library(ggplot2)
 p <- ggplot(data=t, aes(x=prog, y=time, fill=prog))
 p <- p + geom_bar(stat = "identity")
 p <- p + facet_wrap(~ funcs)
 p <- p + theme(axis.title.x=element_blank(), axis.text.x=element_blank(), axis.ticks.x=element_blank())
-p <- p + ylab("time (s)") + ggtitle("Runtime for benchmark variants")
+p <- p + ylab("time (s)") + ggtitle("addr2line runtime")
 ggsave('time.png',plot=p,width=10,height=6)
 
 p <- ggplot(data=t, aes(x=prog, y=mem, fill=prog))
 p <- p + geom_bar(stat = "identity")
 p <- p + facet_wrap(~ funcs)
 p <- p + theme(axis.title.x=element_blank(), axis.text.x=element_blank(), axis.ticks.x=element_blank())
-p <- p + ylab("memory (B)") + ggtitle("Memory use for benchmark variants")
+p <- p + ylab("memory (kB)") + ggtitle("addr2line memory usage")
 ggsave('memory.png',plot=p,width=10,height=6)

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -57,13 +57,19 @@ run() {
 	cmd="$3"
 	args="$4"
 	printf "%s\t%s\t" "$name" "$func"
-	/usr/bin/time -f '%e\t%M' "$cmd" $args -e "$target" < "$addresses" 2>&1 >/dev/null
+	if [[ "$cmd" =~ llvm-symbolizer ]]; then
+		/usr/bin/time -f '%e\t%M' "$cmd" $args -obj="$target" < "$addresses" 2>&1 >/dev/null
+	else
+		/usr/bin/time -f '%e\t%M' "$cmd" $args -e "$target" < "$addresses" 2>&1 >/dev/null
+	fi
 }
 
 # run without functions
 log1=$(mktemp tmp.XXXXXXXXXX)
 echo "==> Benchmarking"
 run nofunc binutils addr2line >> "$log1"
+run nofunc elfutils eu-addr2line >> "$log1"
+run nofunc llvm-sym llvm-symbolizer -functions=none >> "$log1"
 for ref in "$@"; do
 	run nofunc "$ref" "$dirname/target/release/addr2line-$ref" >> "$log1"
 done
@@ -73,6 +79,8 @@ cat "$log1" | column -t
 log2=$(mktemp tmp.XXXXXXXXXX)
 echo "==> Benchmarking with -f"
 run func binutils addr2line -f >> "$log2"
+run func elfutils eu-addr2line -f >> "$log2"
+run func llvm-sym llvm-symbolizer -functions=linkage >> "$log2"
 for ref in "$@"; do
 	run func "$ref" "$dirname/target/release/addr2line-$ref" -f >> "$log2"
 done

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -60,24 +60,27 @@ run() {
 	/usr/bin/time -f '%e\t%M' "$cmd" $args -e "$target" < "$addresses" 2>&1 >/dev/null
 }
 
-log=$(mktemp tmp.XXXXXXXXXX)
-
 # run without functions
+log1=$(mktemp tmp.XXXXXXXXXX)
 echo "==> Benchmarking"
-run nofunc binutils addr2line > "$log"
+run nofunc binutils addr2line >> "$log1"
 for ref in "$@"; do
-	run nofunc "$ref" "$dirname/target/release/addr2line-$ref" >> "$log"
+	run nofunc "$ref" "$dirname/target/release/addr2line-$ref" >> "$log1"
 done
+cat "$log1" | column -t
 
 # run with functions
+log2=$(mktemp tmp.XXXXXXXXXX)
 echo "==> Benchmarking with -f"
-run func binutils addr2line -f >> "$log"
+run func binutils addr2line -f >> "$log2"
 for ref in "$@"; do
-	run func "$ref" "$dirname/target/release/addr2line-$ref" -f >> "$log"
+	run func "$ref" "$dirname/target/release/addr2line-$ref" -f >> "$log2"
 done
+cat "$log2" | column -t
+cat "$log2" >> "$log1"; rm "$log2"
 
 echo "==> Plotting"
-Rscript --no-readline --no-restore --no-save "$dirname/bench.plot.r" < "$log"
+Rscript --no-readline --no-restore --no-save "$dirname/bench.plot.r" < "$log1"
 
 echo "==> Cleaning up"
-rm "$log"
+rm "$log1"


### PR DESCRIPTION
Following suggestions [on Reddit](https://www.reddit.com/r/rust/comments/5i4yms/the_rust_and_gimli_port_of_addr2line_is_now_an/db5dpt9/), this PR adds `eu-addr2line` from elfutils and `llvm-symbolizer` from llvm to the baseline comparisons in our benchmark. It also cleans up the plotting scripts a little more and enhances the resulting graphs.

Current benchmarking results (i.e., not with #19):
![time](https://cloud.githubusercontent.com/assets/176295/21170010/4e39867c-c18f-11e6-81a9-338bef2d73f2.png)
![memory](https://cloud.githubusercontent.com/assets/176295/21170011/4e39c614-c18f-11e6-8d14-b0cc911ca7bc.png)