### PR TITLE
Allow running benchmark.sh while repo is dirty

### DIFF
--- a/benchmark.sh
+++ b/benchmark.sh
@@ -16,79 +16,97 @@ fi
 # readlink -f, but more portable:
 dirname=$(perl -e 'use Cwd "abs_path";print abs_path(shift)' "$(dirname "$0")")
 
-# compile all refs
-pushd "$dirname" > /dev/null
-if ! git diff-index --quiet HEAD --; then
-	echo "Refusing to overwrite outstanding git changes"
-	exit 2
-fi
-current=$(git symbolic-ref --short HEAD)
-for ref in "$@"; do
-	echo "==> Compiling $ref"
-	git checkout -q "$ref"
-	commit=$(git rev-parse HEAD)
-	fn="target/release/addr2line-$commit"
-	if [[ ! -e "$fn" ]]; then
-		cargo build --release
-		cp target/release/addr2line "$fn"
+# http://stackoverflow.com/a/2358432/472927
+{
+	# compile all refs
+	pushd "$dirname" > /dev/null
+	# if the user has some local changes, preserve them
+	nstashed=$(git stash list | wc -l)
+	echo "==> Stashing any local modifications"
+	git stash --keep-index > /dev/null
+	popstash() {
+		# http://stackoverflow.com/q/24520791/472927
+		if [[ "$(git stash list | wc -l)" -ne "$nstashed" ]]; then
+			echo "==> Restoring stashed state"
+			git stash pop > /dev/null
+		fi
+	}
+	# if the user has added stuff to the index, abort
+	if ! git diff-index --quiet HEAD --; then
+		echo "Refusing to overwrite outstanding git changes"
+		popstash
+		exit 2
 	fi
-	if [[ "$ref" != "$commit" ]]; then
-		ln -sfn "addr2line-$commit" target/release/addr2line-"$ref"
-	fi
-done
-git checkout -q "$current"
-popd > /dev/null
+	current=$(git symbolic-ref --short HEAD)
+	for ref in "$@"; do
+		echo "==> Compiling $ref"
+		git checkout -q "$ref"
+		commit=$(git rev-parse HEAD)
+		fn="target/release/addr2line-$commit"
+		if [[ ! -e "$fn" ]]; then
+			cargo build --release
+			cp target/release/addr2line "$fn"
+		fi
+		if [[ "$ref" != "$commit" ]]; then
+			ln -sfn "addr2line-$commit" target/release/addr2line-"$ref"
+		fi
+	done
+	git checkout -q "$current"
+	popstash
+	popd > /dev/null
 
-# get us some addresses to look up
-if [[ -z "$addresses" ]]; then
-	echo "==> Looking for benchmarking addresses (this may take a while)"
-	addresses=$(mktemp tmp.XXXXXXXXXX)
-	objdump -C -x --disassemble -l "$target" \
-		| grep -P '0[048]:' \
-		| awk '{print $1}' \
-		| sed 's/:$//' \
-		> "$addresses"
-	echo "  -> Addresses stored in $addresses; you should re-use it next time"
-fi
-
-run() {
-	func="$1"
-	name="$2"
-	cmd="$3"
-	args="$4"
-	printf "%s\t%s\t" "$name" "$func"
-	if [[ "$cmd" =~ llvm-symbolizer ]]; then
-		/usr/bin/time -f '%e\t%M' "$cmd" $args -obj="$target" < "$addresses" 2>&1 >/dev/null
-	else
-		/usr/bin/time -f '%e\t%M' "$cmd" $args -e "$target" < "$addresses" 2>&1 >/dev/null
+	# get us some addresses to look up
+	if [[ -z "$addresses" ]]; then
+		echo "==> Looking for benchmarking addresses (this may take a while)"
+		addresses=$(mktemp tmp.XXXXXXXXXX)
+		objdump -C -x --disassemble -l "$target" \
+			| grep -P '0[048]:' \
+			| awk '{print $1}' \
+			| sed 's/:$//' \
+			> "$addresses"
+		echo "  -> Addresses stored in $addresses; you should re-use it next time"
 	fi
+
+	run() {
+		func="$1"
+		name="$2"
+		cmd="$3"
+		args="$4"
+		printf "%s\t%s\t" "$name" "$func"
+		if [[ "$cmd" =~ llvm-symbolizer ]]; then
+			/usr/bin/time -f '%e\t%M' "$cmd" $args -obj="$target" < "$addresses" 2>&1 >/dev/null
+		else
+			/usr/bin/time -f '%e\t%M' "$cmd" $args -e "$target" < "$addresses" 2>&1 >/dev/null
+		fi
+	}
+
+	# run without functions
+	log1=$(mktemp tmp.XXXXXXXXXX)
+	echo "==> Benchmarking"
+	run nofunc binutils addr2line >> "$log1"
+	run nofunc elfutils eu-addr2line >> "$log1"
+	run nofunc llvm-sym llvm-symbolizer -functions=none >> "$log1"
+	for ref in "$@"; do
+		run nofunc "$ref" "$dirname/target/release/addr2line-$ref" >> "$log1"
+	done
+	cat "$log1" | column -t
+
+	# run with functions
+	log2=$(mktemp tmp.XXXXXXXXXX)
+	echo "==> Benchmarking with -f"
+	run func binutils addr2line -f >> "$log2"
+	run func elfutils eu-addr2line -f >> "$log2"
+	run func llvm-sym llvm-symbolizer -functions=linkage >> "$log2"
+	for ref in "$@"; do
+		run func "$ref" "$dirname/target/release/addr2line-$ref" -f >> "$log2"
+	done
+	cat "$log2" | column -t
+	cat "$log2" >> "$log1"; rm "$log2"
+
+	echo "==> Plotting"
+	Rscript --no-readline --no-restore --no-save "$dirname/bench.plot.r" < "$log1"
+
+	echo "==> Cleaning up"
+	rm "$log1"
+	exit 0
 }
-
-# run without functions
-log1=$(mktemp tmp.XXXXXXXXXX)
-echo "==> Benchmarking"
-run nofunc binutils addr2line >> "$log1"
-run nofunc elfutils eu-addr2line >> "$log1"
-run nofunc llvm-sym llvm-symbolizer -functions=none >> "$log1"
-for ref in "$@"; do
-	run nofunc "$ref" "$dirname/target/release/addr2line-$ref" >> "$log1"
-done
-cat "$log1" | column -t
-
-# run with functions
-log2=$(mktemp tmp.XXXXXXXXXX)
-echo "==> Benchmarking with -f"
-run func binutils addr2line -f >> "$log2"
-run func elfutils eu-addr2line -f >> "$log2"
-run func llvm-sym llvm-symbolizer -functions=linkage >> "$log2"
-for ref in "$@"; do
-	run func "$ref" "$dirname/target/release/addr2line-$ref" -f >> "$log2"
-done
-cat "$log2" | column -t
-cat "$log2" >> "$log1"; rm "$log2"
-
-echo "==> Plotting"
-Rscript --no-readline --no-restore --no-save "$dirname/bench.plot.r" < "$log1"
-
-echo "==> Cleaning up"
-rm "$log1"


### PR DESCRIPTION
This stashes all changes before running the benchmark, and then pops those changes again (if there were any) after all the binaries have been built. Note that we also need to do a some trickery here to make sure that the bash script doesn't do weird things because we modified it while it was executing (which would happen if `benchmark.sh` itself was dirty).

This patch is best viewed with [`git diff -w`](https://github.com/gimli-rs/addr2line/pull/23/commits/708c18a0fd921bd1e9b3588ac8b322917de1ab3f?w=1)