### PR TITLE
Remove all git dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ build = "build.rs"
 [dependencies]
 fallible-iterator = "0.1.3"
 clap = "2.19.1"
-gimli = { git = "https://github.com/gimli-rs/gimli.git" } # need entries_at_offset
+gimli = "0.11.0"
 memmap = "0.5.0"
 object = "0.1.0"
-owning_ref = { git = "https://github.com/Kimundi/owning-ref-rs" } # need OwningHandle
+owning_ref = "0.2.4"
 error-chain = "0.7.1"
 rustc-demangle = "0.1.3"
 


### PR DESCRIPTION
Now that gimli [0.11.0](https://github.com/gimli-rs/gimli/commit/2a8d3286cb7f3cdede333813d74fbe6e30aa8aaf) and owning-ref [2.2.4](https://github.com/Kimundi/owning-ref-rs/commit/c00676ea361eae657cfda05bf14fbca3390d0a23) are both out, all the features we depend on from those crates have been released. This PR replaces the git dependencies for those crates with the appropriate version dependencies instead, which should also allow us to publish a new (and much needed) version of addr2line to crates.io.