### PR TITLE
Add support for C++ symbol demangling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ before_script:
 - if [[ -e ~/.local/bin ]]; then export PATH=~/.local/bin:$PATH; fi
 
 script:
+-  travis-cargo build -- --no-default-features
+-  travis-cargo build -- --no-default-features --features "cpp_demangle"
+-  travis-cargo build -- --no-default-features --features "rustc-demangle"
 -  travis-cargo build
 -  if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then travis-cargo test; fi
 -  travis-cargo bench

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ memmap = "0.5.0"
 object = "0.1.0"
 owning_ref = "0.2.4"
 error-chain = "0.7.1"
-rustc-demangle = "0.1.3"
+cpp_demangle = { version = "0.2.0", optional = true }
+rustc-demangle = { version = "0.1.3", optional = true }
 
 [dev-dependencies]
 glob = "0.2"
@@ -30,3 +31,5 @@ itertools = "0.5"
 
 [features]
 nightly = []
+demangle = ["cpp_demangle", "rustc-demangle"]
+default = ["demangle"]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -89,7 +89,10 @@ fn with_functions() {
     let debug = target.clone();
 
     // Parse the debug symbols using "our" addr2line
-    let ours = addr2line::Mapping::with_functions(&debug).unwrap();
+    let ours = addr2line::Options::default()
+        .with_functions()
+        .build(&debug)
+        .unwrap();
 
     // Spin up the "real" addr2line
     let mut theirs = spawn_oracle(target.as_path(), &["-f"]);


### PR DESCRIPTION
The `cpp_demangle` crate doesn't match libiberty 100% yet, but it is in a good enough place that we can get some utility out of it here.

Fixes #17 

r? @jonhoo 