### PR TITLE
Bump to version 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0/MIT"
 name = "addr2line"
 readme = "./README.md"
 repository = "https://github.com/gimli-rs/addr2line"
-version = "0.2.1"
+version = "0.3.0"
 build = "build.rs"
 
 [badges]


### PR DESCRIPTION
There were some minor breaking changes to the public interface, hence the bump
from 0.2.X to 0.3.X.

r? @jonhoo or anyone else who wants to rubber stamp this