### PR TITLE
Bump to version 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0/MIT"
 name = "addr2line"
 readme = "./README.md"
 repository = "https://github.com/gimli-rs/addr2line"
-version = "0.4.0"
+version = "0.5.0"
 build = "build.rs"
 
 [badges]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ extern crate addr2line;
 fn main() {
     use std::env;
     let us = env::current_exe().expect("not running as an executable");
-    let map = addr2line::Mapping::new(&us).expect("debug symbols not found");
+    let mut map = addr2line::Mapping::new(&us).expect("debug symbols not found");
     let addr = env::args().skip(1).next().expect("no address passed");
     let addr = u64::from_str_radix(&addr[2..], 16).expect("address not valid");
     let loc = map.locate(addr as u64).expect("invalid debug symbols found");


### PR DESCRIPTION
Breaking bump because `Mapping::locate` changed from `&self` to `&mut self`.

r? @philipc 