### PR TITLE
Various cleanup

### DIFF
--- a/src/bin/addr2line.rs
+++ b/src/bin/addr2line.rs
@@ -128,7 +128,9 @@ fn main() {
             println!(
                 "{}:{}",
                 file.to_string_lossy(),
-                lineno.map(|n| format!("{}", n)).unwrap_or("?".to_owned())
+                lineno
+                    .map(|n| format!("{}", n))
+                    .unwrap_or_else(|| "?".to_owned())
             );
         } else {
             if show_funcs {

--- a/src/bin/addr2line.rs
+++ b/src/bin/addr2line.rs
@@ -1,6 +1,6 @@
+extern crate addr2line;
 #[macro_use]
 extern crate clap;
-extern crate addr2line;
 
 use clap::{App, Arg};
 
@@ -59,9 +59,7 @@ fn get_matches() -> clap::ArgMatches<'static> {
             Arg::with_name("functions")
                 .short("f")
                 .long("functions")
-                .help(
-                    "Display function names as well as file and line number information.",
-                ),
+                .help("Display function names as well as file and line number information."),
         )
         .arg(Arg::with_name("addr").multiple(true).index(1))
         .after_help(POSTSCRIPT)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,11 +21,11 @@
 //! is specified with the -e option. The default is the file a.out.
 #![deny(missing_docs)]
 
+extern crate fallible_iterator;
 extern crate gimli;
 extern crate memmap;
 extern crate object;
 extern crate owning_ref;
-extern crate fallible_iterator;
 
 #[cfg(feature = "rustc-demangle")]
 extern crate rustc_demangle;
@@ -366,11 +366,9 @@ where
             let row = row.unwrap();
             let header = unit.lines.program_rows.header();
 
-            let file = header
-                .file(row.file_index)
-                .ok_or_else(|| {
-                    ErrorKind::InvalidDebugSymbols(DebugInfoError::InvalidDebugLineTarget)
-                })?;
+            let file = header.file(row.file_index).ok_or_else(|| {
+                ErrorKind::InvalidDebugSymbols(DebugInfoError::InvalidDebugLineTarget)
+            })?;
 
             let mut path = path::PathBuf::new();
             if let Some(directory) = file.directory(header) {
@@ -518,7 +516,6 @@ where
         header: &gimli::CompilationUnitHeader<gimli::EndianBuf<'input, Endian>>,
         opts: Options,
     ) -> Result<Option<Unit<'input, Endian>>> {
-
         // We first want to parse out the compilation unit, and then any contained subprograms.
         let abbrev = header
             .abbreviations(debug_abbrev)
@@ -618,7 +615,6 @@ where
             .next_dfs()
             .chain_err(|| "tree below compilation unit yielded invalid entry")?
         {
-
             // We only care about functions
             match entry.tag() {
                 gimli::DW_TAG_inlined_subroutine | gimli::DW_TAG_subprogram => (),
@@ -646,14 +642,13 @@ where
             // exhibit the same behavior, but it is something we should aim to eventually work
             // around. Hence: TODO
 
-            let maybe_name = Self::resolve_name(entry, header, debug_str, &abbrev)
-                .chain_err(|| {
-                    format!(
-                        "failed to resolve name for subroutine at <{:x}><{:x}>",
-                        header.offset().0,
-                        entry.offset().0
-                    )
-                })?;
+            let maybe_name = Self::resolve_name(entry, header, debug_str, &abbrev).chain_err(|| {
+                format!(
+                    "failed to resolve name for subroutine at <{:x}><{:x}>",
+                    header.offset().0,
+                    entry.offset().0
+                )
+            })?;
 
             if let Some(name) = maybe_name {
                 unit.programs.push(Program {
@@ -673,7 +668,6 @@ where
         debug_str: &gimli::DebugStr<gimli::EndianBuf<'input, Endian>>,
         abbrev: &gimli::Abbreviations,
     ) -> Result<Option<gimli::EndianBuf<'input, Endian>>> {
-
         // For naming, we prefer the linked name, if available
         if let Some(name) = entry
             .attr(gimli::DW_AT_linkage_name)
@@ -734,11 +728,9 @@ where
             .map_err(|e| Error::from(ErrorKind::Gimli(e)))?
         {
             let mut entries = header.entries_at_offset(abbrev, offset)?;
-            let (_, entry) = entries
-                .next_dfs()?
-                .ok_or_else(|| {
-                    ErrorKind::InvalidDebugSymbols(DebugInfoError::DanglingEntryOffset)
-                })?;
+            let (_, entry) = entries.next_dfs()?.ok_or_else(|| {
+                ErrorKind::InvalidDebugSymbols(DebugInfoError::DanglingEntryOffset)
+            })?;
             return Ok(Some(entry.clone()));
         }
 
@@ -756,9 +748,7 @@ where
         {
             return Ok(range);
         }
-        if let Some(range) = Self::parse_contiguous_range(entry)?
-            .map(|range| vec![range])
-        {
+        if let Some(range) = Self::parse_contiguous_range(entry)?.map(|range| vec![range]) {
             return Ok(range);
         }
         Ok(vec![])
@@ -821,9 +811,7 @@ where
         }
 
         if low_pc > high_pc {
-            return Err(
-                ErrorKind::InvalidDebugSymbols(DebugInfoError::RangeInverted).into(),
-            );
+            return Err(ErrorKind::InvalidDebugSymbols(DebugInfoError::RangeInverted).into());
         }
 
         Ok(Some(gimli::Range {
@@ -850,8 +838,7 @@ where
 {
     ranges: Vec<gimli::Range>,
     name: gimli::EndianBuf<'input, Endian>,
-    #[allow(dead_code)]
-    inlined: bool,
+    #[allow(dead_code)] inlined: bool,
 }
 
 impl<'input, Endian> Program<'input, Endian>
@@ -888,8 +875,7 @@ where
         comp_dir: Option<gimli::EndianBuf<'input, Endian>>,
         comp_name: Option<gimli::EndianBuf<'input, Endian>>,
     ) -> Result<Self> {
-        let program = debug_line
-            .program(line_offset, address_size, comp_dir, comp_name)?;
+        let program = debug_line.program(line_offset, address_size, comp_dir, comp_name)?;
         Ok(Lines {
             program_rows: program.rows(),
             sequences: Vec::new(),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -266,8 +266,8 @@ fn canonicalize_oracle_output(line: &str) -> (Option<&str>, Option<u64>) {
     let mut oracle = (file, lineno);
 
     // Workaround binutils addr2line bug.
-    if oracle ==
-        (
+    if oracle
+        == (
             Some("/checkout/src/liballoc_jemalloc/../jemalloc/src/prof.c"),
             Some(2093),
         ) {


### PR DESCRIPTION
The integration test was failing because we are returning a filename for the main() wrapper, but binutils doesn't. I changed the integration test to ignore this case.

Also run rustfmt and clippy.