### PR TITLE
Ignore self tests for now

### DIFF
--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -36,11 +36,13 @@ fn release_fixture_path() -> (PathBuf, PathBuf) {
 }
 
 #[test]
+#[ignore] // FIXME: hangs sometimes
 fn self_identity_map() {
     identity_map(self_path())
 }
 
 #[test]
+#[ignore] // FIXME: hangs a lot
 #[cfg(not(target_os = "macos"))]
 fn self_with_functions() {
     with_functions(self_path())


### PR DESCRIPTION
Experiencing frequent hangs when running them under code coverage tools.
I've also seen a hang running standalone too.

When the hang occurs, CPU usage drops to 0 and strace says the test
process is waiting on a futex.