### PR TITLE
 Handle overlapping unit ranges 

### DIFF
--- a/tests/correctness.rs
+++ b/tests/correctness.rs
@@ -59,3 +59,23 @@ fn test_frame_3() {
     });
     no_tailcall_please();
 }
+
+#[test]
+fn zero_sequence() {
+    let map = memmap::Mmap::open_path("/proc/self/exe", memmap::Protection::Read).unwrap();
+    let file = &object::File::parse(unsafe { map.as_slice() }).unwrap();
+    let ctx = Context::new(file).unwrap();
+    for probe in 0..10 {
+        assert!(ctx.find_location(probe).unwrap().is_none());
+    }
+}
+
+#[test]
+fn zero_function() {
+    let map = memmap::Mmap::open_path("/proc/self/exe", memmap::Protection::Read).unwrap();
+    let file = &object::File::parse(unsafe { map.as_slice() }).unwrap();
+    let ctx = Context::new(file).unwrap().parse_functions().unwrap();
+    for probe in 0..10 {
+        assert!(ctx.query(probe).unwrap().next().unwrap().is_none());
+    }
+}


### PR DESCRIPTION
And ignore sequences and functions that start at 0.

Fixes #67