### PR TITLE
Fix code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,5 +35,5 @@ script:
 after_success:
 - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_RUST_VERSION" == "stable" ]]; then
     bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh);
-    cargo tarpaulin --no-count --ciserver travis-ci --coveralls $TRAVIS_JOB_ID;
+    cargo tarpaulin --verbose --no-count --ciserver travis-ci --coveralls $TRAVIS_JOB_ID;
   fi


### PR DESCRIPTION
Stop tarpaulin passing a --quiet flag to the tests, which fails with:

thread 'main' panicked at '"Unrecognized option: \'quiet\'"', /home/travis/.cargo/registry/src/github.com-1ecc6299db9ec823/rustc-test-0.2.0/src/lib.rs:266:26