### PR TITLE
 Add symbol table fallback to addr2line example 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "gimli-rs/addr2line" }
 [dependencies]
 gimli = "0.14"
 fallible-iterator = "0.1"
-object = "0.4"
+object = "0.7"
 intervaltree = "0.2"
 smallvec = "0.4"
 rustc-demangle = { version = "0.1", optional = true }

--- a/examples/addr2line.rs
+++ b/examples/addr2line.rs
@@ -147,7 +147,8 @@ fn main() {
     let path = matches.value_of("exe").unwrap();
 
     let map = memmap::Mmap::open_path(path, memmap::Protection::Read).unwrap();
-    let file = &object::File::parse(unsafe { map.as_slice() }).unwrap();
+    let file =
+        &object::File::parse(unsafe { map.as_slice() }).unwrap();
 
     let ctx = Context::new(file).unwrap();
 


### PR DESCRIPTION
It would have been nice to change `FunctionName` to hold `Cow<str>` instead of `gimli::Reader` so that symbols could be `FunctionName`s too, but the lifetime on `Reader::to_string_lossy` doesn't allow that.

Demangling is a bunch of small functions again, but I don't see how to do better.