### PR TITLE
Update object to 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "gimli-rs/addr2line" }
 [dependencies]
 gimli = "0.16"
 fallible-iterator = "0.1"
-object = "0.7"
+object = "0.9"
 intervaltree = "0.2"
 smallvec = "0.6"
 lazycell = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,6 +142,27 @@ impl<'a> Context<gimli::EndianSlice<'a, gimli::RunTimeEndian>> {
         let debug_rnglists: gimli::DebugRngLists<_> = load_section(file, endian);
         let debug_str: gimli::DebugStr<_> = load_section(file, endian);
 
+        Context::from_sections(
+            debug_abbrev,
+            debug_info,
+            debug_line,
+            debug_ranges,
+            debug_rnglists,
+            debug_str,
+        )
+    }
+}
+
+impl<R: gimli::Reader> Context<R> {
+    /// Construct a new `Context` from DWARF sections.
+    pub fn from_sections(
+        debug_abbrev: gimli::DebugAbbrev<R>,
+        debug_info: gimli::DebugInfo<R>,
+        debug_line: gimli::DebugLine<R>,
+        debug_ranges: gimli::DebugRanges<R>,
+        debug_rnglists: gimli::DebugRngLists<R>,
+        debug_str: gimli::DebugStr<R>,
+    ) -> Result<Self, Error> {
         let range_lists = gimli::RangeLists::new(debug_ranges, debug_rnglists)?;
 
         let mut unit_ranges = Vec::new();


### PR DESCRIPTION
Also use the `Object` trait instead of `File` (see https://github.com/gimli-rs/object/issues/53).

~~This requires https://github.com/gimli-rs/gimli/pull/305.~~

I played a bit with using `Rc/Arc<Cow<'input, [u8]>>` instead of `EndianRcSlice`, but wasn't sure it was worth the API complexity. So I think `Context::new` should be the simple high level interface, and consumers with more specific needs can use `Context::from_sections`.

Before:
```
test context_new_and_query_location       ... bench:     951,031 ns/iter (+/- 79,277)
test context_new_and_query_with_functions ... bench:   1,760,225 ns/iter (+/- 54,934)
test context_new_location                 ... bench:     760,223 ns/iter (+/- 57,231)
test context_new_with_functions           ... bench:     751,183 ns/iter (+/- 55,055)
test context_query_location               ... bench:  10,378,538 ns/iter (+/- 92,496)
test context_query_with_functions         ... bench:  11,578,429 ns/iter (+/- 142,557)
```

After:
```
test context_new_and_query_location       ... bench:   5,527,469 ns/iter (+/- 285,657)
test context_new_and_query_with_functions ... bench:   6,809,893 ns/iter (+/- 490,899)
test context_new_location                 ... bench:   5,230,294 ns/iter (+/- 307,209)
test context_new_with_functions           ... bench:   5,213,000 ns/iter (+/- 266,617)
test context_query_location               ... bench:  15,353,989 ns/iter (+/- 309,998)
test context_query_with_functions         ... bench:  16,591,755 ns/iter (+/- 402,449)
```

For reference, `Arc<Cow<[u8]>>`:
```
test context_new_and_query_location       ... bench:   1,063,159 ns/iter (+/- 57,010)
test context_new_and_query_with_functions ... bench:   2,483,267 ns/iter (+/- 180,353)
test context_new_location                 ... bench:     758,812 ns/iter (+/- 16,336)
test context_new_with_functions           ... bench:     755,755 ns/iter (+/- 31,252)
test context_query_location               ... bench:  18,362,107 ns/iter (+/- 417,995)
test context_query_with_functions         ... bench:  19,264,415 ns/iter (+/- 260,564)
```
The query numbers for `Arc<Cow<[u8]>>` are surprising to me, but I didn't look into it.