### PR TITLE
Fix compile error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,9 @@ use alloc::rc::Rc;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
+#[cfg(feature = "rustc-demangle")]
+use alloc::format;
+
 use std::cmp::Ordering;
 use std::u64;
 


### PR DESCRIPTION
The combination of default-features = false, features = ["alloc", "rustc-demangle"] fails to compile since the library is missing an import to format! in this case.