### PR TITLE
Fix build with `--no-default-features`

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -21,6 +21,7 @@ case "$GIMLI_JOB" in
         ;;
 
     "nightly_features")
+        cargo build --no-default-features
         cargo build --no-default-features --features "alloc"
         cargo build --no-default-features --features "alloc object"
         ;;


### PR DESCRIPTION
Avoid having a defaulted type parameter with `EndianRcSlice` when no
features are activated to ensure that the library builds correctly.