### PR TITLE
Ignore broken units in Context<R>::from_sections.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,7 +174,10 @@ impl<R: gimli::Reader> Context<R> {
         let mut units = sections.units();
         while let Some(header) = units.next()? {
             let unit_id = res_units.len();
-            let dw_unit = sections.unit(header)?;
+            let dw_unit = match sections.unit(header) {
+                Ok(dw_unit) => dw_unit,
+                Err(_) => continue,
+            };
 
             let lang;
             {


### PR DESCRIPTION
Fixes #132. r? @philipc 

I don't know if I'm using the right words in the commit message, how to find out what the type of the "broken" units is or what this means about the validity of the DWARF data. I also don't know how to slim the testcase down into something that could become a real test.