### PR TITLE
Add `Context::from_dwarf` constructor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ impl<R: gimli::Reader> Context<R> {
         debug_str_offsets: gimli::DebugStrOffsets<R>,
         default_section: R,
     ) -> Result<Self, Error> {
-        let sections = gimli::Dwarf {
+        Self::from_dwarf(gimli::Dwarf {
             debug_abbrev,
             debug_addr,
             debug_info,
@@ -167,8 +167,11 @@ impl<R: gimli::Reader> Context<R> {
                 default_section.clone().into(),
             ),
             ranges: gimli::RangeLists::new(debug_ranges, debug_rnglists),
-        };
+        })
+    }
 
+    /// Construct a new `Context` from an existing [`gimli::Dwarf`] object.
+    pub fn from_dwarf(sections: gimli::Dwarf<R>) -> Result<Self, Error> {
         let mut unit_ranges = Vec::new();
         let mut res_units = Vec::new();
         let mut units = sections.units();


### PR DESCRIPTION
When one already has a `gimli::Dwarf` object created with a custom `gimli::Dwarf::load` invocation, it's not very convenient to deconstruct it to separate sections just to create a `Context`.

Given that `Context` already uses `gimli::Dwarf` internally, let's expose an additional constructor that allows to take it.