### PR TITLE
Add benchmarks for the lazily parsed data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ rustc-test = "0.3"
 debug = true
 [profile.bench]
 debug = true
+codegen-units = 1
 
 [features]
 default = ["rustc-demangle", "cpp_demangle", "std-object"]

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -50,12 +50,36 @@ fn get_test_addresses(target: &object::File) -> Vec<u64> {
 }
 
 #[bench]
-fn context_new_location(b: &mut test::Bencher) {
+fn context_new(b: &mut test::Bencher) {
     let target = release_fixture_path();
 
     with_file(&target, |file| {
         b.iter(|| {
             addr2line::Context::new(file).unwrap();
+        });
+    });
+}
+
+#[bench]
+fn context_new_parse_lines(b: &mut test::Bencher) {
+    let target = release_fixture_path();
+
+    with_file(&target, |file| {
+        b.iter(|| {
+            let context = addr2line::Context::new(file).unwrap();
+            context.parse_lines().unwrap();
+        });
+    });
+}
+
+#[bench]
+fn context_new_parse_functions(b: &mut test::Bencher) {
+    let target = release_fixture_path();
+
+    with_file(&target, |file| {
+        b.iter(|| {
+            let context = addr2line::Context::new(file).unwrap();
+            context.parse_functions().unwrap();
         });
     });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,6 +296,24 @@ impl<R: gimli::Reader> Context<R> {
             next: loc,
         })
     }
+
+    /// Initialize all line data structures. This is used for benchmarks.
+    #[doc(hidden)]
+    pub fn parse_lines(&self) -> Result<(), Error> {
+        for unit in &self.units {
+            unit.parse_lines(&self.sections)?;
+        }
+        Ok(())
+    }
+
+    /// Initialize all function data structures. This is used for benchmarks.
+    #[doc(hidden)]
+    pub fn parse_functions(&self) -> Result<(), Error> {
+        for unit in &self.units {
+            unit.parse_functions(&self.sections)?;
+        }
+        Ok(())
+    }
 }
 
 struct Lines {


### PR DESCRIPTION
Also disable parallel codegen for benchmarks. This improves the benchmarks due to better inlining, and makes them a more reliable tool for determining the effect of code changes.

Before:
```
test context_new_and_query_location       ... bench:   3,111,057 ns/iter (+/- 530,666)
test context_new_and_query_with_functions ... bench:   4,172,368 ns/iter (+/- 556,175)
test context_new_location                 ... bench:   2,857,732 ns/iter (+/- 152,999)
test context_query_location               ... bench:     713,752 ns/iter (+/- 45,922)
test context_query_with_functions         ... bench:   4,526,699 ns/iter (+/- 567,636)
```

After:
```
test context_new_and_query_location       ... bench:   2,953,517 ns/iter (+/- 103,705)
test context_new_and_query_with_functions ... bench:   3,803,000 ns/iter (+/- 610,173)
test context_new_location                 ... bench:   2,784,894 ns/iter (+/- 694,324)
test context_query_location               ... bench:     717,903 ns/iter (+/- 62,360)
test context_query_with_functions         ... bench:   4,258,835 ns/iter (+/- 171,619)
```
