### PR TITLE
Use gimli::EntriesRaw

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["/benches/*", "/fixtures/*"]
 travis-ci = { repository = "gimli-rs/addr2line" }
 
 [dependencies]
-gimli = { version = "0.19", default-features = false, features = ["read"] }
+gimli = { version = "0.19", default-features = false, features = ["read"], git = "https://github.com/gimli-rs/gimli.git", rev = "1b7706bc87938916b4df4cda0c7d1346e938fe86" }
 fallible-iterator = { version = "0.2", default-features = false }
 object = { version = "0.12", default-features = false, optional = true }
 intervaltree = { version = "0.2", default-features = false }


### PR DESCRIPTION
```
 name                                        before ns/iter  after ns/iter  diff ns/iter   diff %  speedup
 context_new_and_query_location_rc           2,801,330       2,756,426           -44,904   -1.60%   x 1.02
 context_new_and_query_location_slice        799,066         813,226              14,160    1.77%   x 0.98
 context_new_and_query_with_functions_rc     3,669,702       3,353,516          -316,186   -8.62%   x 1.09
 context_new_and_query_with_functions_slice  1,185,584       1,235,567            49,983    4.22%   x 0.96
 context_new_parse_functions_rc              57,176,047      39,507,103      -17,668,944  -30.90%   x 1.45
 context_new_parse_functions_slice           26,040,739      28,291,537        2,250,798    8.64%   x 0.92
 context_new_parse_lines_rc                  12,698,606      12,417,588         -281,018   -2.21%   x 1.02
 context_new_parse_lines_slice               8,007,306       7,807,168          -200,138   -2.50%   x 1.03
 context_new_rc                              2,651,232       2,712,836            61,604    2.32%   x 0.98
 context_new_slice                           641,597         655,136              13,539    2.11%   x 0.98
 context_query_location_rc                   753,177         753,764                 587    0.08%   x 1.00
 context_query_location_slice                756,170         761,125               4,955    0.66%   x 0.99
 context_query_with_functions_rc             4,676,450       4,472,784          -203,666   -4.36%   x 1.05
 context_query_with_functions_slice          4,534,111       4,545,788            11,677    0.26%   x 1.00
 new                                         36,062          30,994               -5,068  -14.05%   x 1.16
 new_unresolved_and_resolve_separate         35,224          30,497               -4,727  -13.42%   x 1.15
 trace_and_resolve_callback                  20,783          14,604               -6,179  -29.73%   x 1.42
 trace_and_resolve_separate                  17,765          12,919               -4,846  -27.28%   x 1.38
```

The last 4 benchmarks are from backtrace-rs.

A number of benchmarks are slower, but these are due to differences in
inlining of `gimli::parse_attribute`. If I force inlining, then the
results are better, but I'm reluctant to do that for such a large
function:

```
 name                                        before ns/iter  after ns/iter  diff ns/iter   diff %  speedup
 context_new_and_query_with_functions_rc     3,669,702       3,326,154          -343,548   -9.36%   x 1.10
 context_new_and_query_with_functions_slice  1,185,584       1,142,493           -43,091   -3.63%   x 1.04
 context_new_parse_functions_rc              57,176,047      35,920,683      -21,255,364  -37.18%   x 1.59
 context_new_parse_functions_slice           26,040,739      21,677,801       -4,362,938  -16.75%   x 1.20
```