### PR TITLE
Replace IntervalTree with Vec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,6 @@ harness = false
 
 [[test]]
 name = "correctness"
+
+[[test]]
+name = "parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ travis-ci = { repository = "gimli-rs/addr2line" }
 gimli = { version = "0.19", default-features = false, features = ["read"], git = "https://github.com/gimli-rs/gimli.git", rev = "1b7706bc87938916b4df4cda0c7d1346e938fe86" }
 fallible-iterator = { version = "0.2", default-features = false }
 object = { version = "0.16", default-features = false, features = ["read"], optional = true }
-intervaltree = { version = "0.2", default-features = false }
 smallvec = { version = "1", default-features = false }
 lazycell = "1"
 rustc-demangle = { version = "0.1", optional = true }
@@ -39,7 +38,7 @@ codegen-units = 1
 
 [features]
 default = ["rustc-demangle", "cpp_demangle", "std-object"]
-std = ["gimli/std", "intervaltree/std"]
+std = ["gimli/std"]
 std-object = ["std", "object", "object/std"]
 alloc = ["gimli/alloc"]
 

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -1,0 +1,115 @@
+extern crate addr2line;
+extern crate memmap;
+extern crate object;
+
+use std::borrow::Cow;
+use std::env;
+use std::fs::File;
+use std::path::{self, PathBuf};
+
+use object::Object;
+
+fn release_fixture_path() -> PathBuf {
+    if let Ok(p) = env::var("ADDR2LINE_FIXTURE_PATH") {
+        return p.into();
+    }
+
+    let mut path = PathBuf::new();
+    if let Ok(dir) = env::var("CARGO_MANIFEST_DIR") {
+        path.push(dir);
+    }
+    path.push("fixtures");
+    path.push("addr2line-release");
+    path
+}
+
+fn with_file<F: FnOnce(&object::File)>(target: &path::Path, f: F) {
+    let file = File::open(target).unwrap();
+    let map = unsafe { memmap::Mmap::map(&file).unwrap() };
+    let file = object::File::parse(&*map).unwrap();
+    f(&file)
+}
+
+fn dwarf_load<'a>(object: &object::File<'a>) -> gimli::Dwarf<Cow<'a, [u8]>> {
+    let load_section = |id: gimli::SectionId| -> Result<Cow<'a, [u8]>, gimli::Error> {
+        Ok(object
+            .section_data_by_name(id.name())
+            .unwrap_or(Cow::Borrowed(&[][..])))
+    };
+    let load_section_sup = |_| Ok(Cow::Borrowed(&[][..]));
+    gimli::Dwarf::load(&load_section, &load_section_sup).unwrap()
+}
+
+fn dwarf_borrow<'a>(
+    dwarf: &'a gimli::Dwarf<Cow<[u8]>>,
+) -> gimli::Dwarf<gimli::EndianSlice<'a, gimli::LittleEndian>> {
+    let borrow_section: &dyn for<'b> Fn(
+        &'b Cow<[u8]>,
+    ) -> gimli::EndianSlice<'b, gimli::LittleEndian> =
+        &|section| gimli::EndianSlice::new(&*section, gimli::LittleEndian);
+    dwarf.borrow(&borrow_section)
+}
+
+#[test]
+fn parse_base_rc() {
+    let target = release_fixture_path();
+
+    with_file(&target, |file| {
+        addr2line::Context::new(file).unwrap();
+    });
+}
+
+#[test]
+fn parse_base_slice() {
+    let target = release_fixture_path();
+
+    with_file(&target, |file| {
+        let dwarf = dwarf_load(file);
+        let dwarf = dwarf_borrow(&dwarf);
+        addr2line::Context::from_dwarf(dwarf).unwrap();
+    });
+}
+
+#[test]
+fn parse_lines_rc() {
+    let target = release_fixture_path();
+
+    with_file(&target, |file| {
+        let context = addr2line::Context::new(file).unwrap();
+        context.parse_lines().unwrap();
+    });
+}
+
+#[test]
+fn parse_lines_slice() {
+    let target = release_fixture_path();
+
+    with_file(&target, |file| {
+        let dwarf = dwarf_load(file);
+        let dwarf = dwarf_borrow(&dwarf);
+        let context = addr2line::Context::from_dwarf(dwarf).unwrap();
+        context.parse_lines().unwrap();
+    });
+}
+
+#[test]
+fn parse_functions_rc() {
+    let target = release_fixture_path();
+
+    with_file(&target, |file| {
+        let context = addr2line::Context::new(file).unwrap();
+        context.parse_functions().unwrap();
+    });
+}
+
+#[test]
+fn parse_functions_slice() {
+    let target = release_fixture_path();
+
+    with_file(&target, |file| {
+        let dwarf = dwarf_load(file);
+        let dwarf = dwarf_borrow(&dwarf);
+        let context = addr2line::Context::from_dwarf(dwarf).unwrap();
+        context.parse_functions().unwrap();
+    });
+}


### PR DESCRIPTION
`IntervalTree` doesn't perform as well as a simple tree of `Vec`s. Note that a `Vec` tree can't handle partially overlapping intervals, but we don't need that.

```
 name                                        before ns/iter  after ns/iter  diff ns/iter   diff %  speedup
 context_new_and_query_location_rc           2,427,320       2,432,182             4,862    0.20%   x 1.00
 context_new_and_query_location_slice        765,873         758,006              -7,867   -1.03%   x 1.01
 context_new_and_query_with_functions_rc     2,993,102       2,959,278           -33,824   -1.13%   x 1.01
 context_new_and_query_with_functions_slice  1,133,112       1,152,324            19,212    1.70%   x 0.98
 context_new_parse_functions_rc              31,235,025      33,387,535        2,152,510    6.89%   x 0.94
 context_new_parse_functions_slice           23,754,161      26,858,657        3,104,496   13.07%   x 0.88
 context_new_parse_lines_rc                  11,725,686      11,711,061          -14,625   -0.12%   x 1.00
 context_new_parse_lines_slice               7,337,852       7,283,802           -54,050   -0.74%   x 1.01
 context_new_rc                              2,207,283       2,162,930           -44,353   -2.01%   x 1.02
 context_new_slice                           613,189         603,892              -9,297   -1.52%   x 1.02
 context_query_location_rc                   728,349         733,083               4,734    0.65%   x 0.99
 context_query_location_slice                721,907         729,294               7,387    1.02%   x 0.99
 context_query_with_functions_rc             4,292,707       1,952,886        -2,339,821  -54.51%   x 2.20
 context_query_with_functions_slice          4,302,388       1,744,765        -2,557,623  -59.45%   x 2.47
 new                                         28,964          27,013               -1,951   -6.74%   x 1.07
 new_unresolved_and_resolve_separate         29,332          26,986               -2,346   -8.00%   x 1.09
 trace_and_resolve_callback                  13,379          11,471               -1,908  -14.26%   x 1.17
 trace_and_resolve_separate                  11,013          9,801                -1,212  -11.01%   x 1.12
```

For the test `parse_functions_slice`, memory usage increased from 17.4MB to 19.7MB.

Also save some memory by using `Box` for line rows.