### PR TITLE
added api that exposes the whole source mapping

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,6 +370,39 @@ impl<R: gimli::Reader> Context<R> {
         }
         Ok(())
     }
+
+    /// Returns a copy of the whole Source Map.
+    pub fn copy_line_infos(&self) -> Vec<LineInfo> {
+        let mut res = vec![];
+        for unit in self.units.iter() {
+            if let Ok(Some(lines)) = unit.parse_lines(&self.sections) {
+                for seq in lines.sequences.iter() {
+                    for row in seq.rows.iter() {
+                        let inf = LineInfo {
+                            address: row.address,
+                            file: &lines.files[row.file_index as usize],
+                            line: row.line,
+                            column: row.column,
+                        };
+                        res.push(inf);
+                    }
+                }
+            }
+        }
+        return res;
+    }
+}
+
+///Contains source mapping information for the given bytes starting at the given address
+pub struct LineInfo<'a> {
+    ///the start address of this source mapping
+    pub address: u64,
+    ///the filename of the file where this source line resides
+    pub file: &'a str,
+    ///the line number that emmited these bytes
+    pub line: Option<u64>,
+    ///the column that emitted these bytes
+    pub column: Option<u64>,
 }
 
 struct Lines {

--- a/tests/correctness.rs
+++ b/tests/correctness.rs
@@ -58,3 +58,14 @@ fn zero_function() {
         assert!(ctx.find_frames(probe).unwrap().next().unwrap().is_none());
     }
 }
+
+#[test]
+fn iter_lines_function() {
+    let file = File::open("/proc/self/exe").unwrap();
+    let map = unsafe { memmap::Mmap::map(&file).unwrap() };
+    let file = &object::File::parse(&*map).unwrap();
+    let ctx = Context::new(file).unwrap();
+    let info = ctx.copy_line_infos();
+    //check that we include at least the current file in the mapping
+    assert!(info.iter().any(|line| line.file.ends_with(file!())));
+}


### PR DESCRIPTION
A proposal for #149

The rational behind this design:

- it avoids exposing any of your internal data structures
- it avoids adding any additional dependencies by returning a reference (HashMap could have been useful to create a owned version of all paths across the individual units). 

Would you feel comfortable to maintain this? If not, what needs to be changed?