### PR TITLE
addr2line: update to match newer binutils

### DIFF
--- a/examples/addr2line.rs
+++ b/examples/addr2line.rs
@@ -63,7 +63,7 @@ fn print_loc(loc: &Option<Location>, basenames: bool, llvm: bool) {
     } else if llvm {
         println!("??:0:0");
     } else {
-        println!("??:0");
+        println!("??:?");
     }
 }
 
@@ -218,7 +218,7 @@ fn main() {
                     }
 
                     if pretty {
-                        print!(" ");
+                        print!(" at ");
                     } else {
                         println!();
                     }
@@ -227,7 +227,7 @@ fn main() {
                 if llvm {
                     println!("??:0:0");
                 } else {
-                    println!("??:0");
+                    println!("??:?");
                 }
             }
         } else {


### PR DESCRIPTION
Somewhere between version 2.22 and 2.30, the binutils addr2line output for unknown lines changed from "??:0" to "??:?".

@kentfredric Can you check this fixes the tests for you?