### PR TITLE
Delete alloc feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,3 @@ matrix:
     # Benching should only happen on nightly.
     - rust: nightly
       env: GIMLI_JOB="bench"
-    # Some features require nightly.
-    - rust: nightly
-      env: GIMLI_JOB="nightly_features"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ exclude = ["/benches/*", "/fixtures/*"]
 travis-ci = { repository = "gimli-rs/addr2line" }
 
 [dependencies]
-gimli = { version = "0.19", default-features = false, features = ["read"], git = "https://github.com/gimli-rs/gimli.git", rev = "1b7706bc87938916b4df4cda0c7d1346e938fe86" }
+gimli = { version = "0.19", default-features = false, features = ["read"], git = "https://github.com/gimli-rs/gimli.git", rev = "8728e82cea96df9a3060607e4bf91584f33368e8" }
 fallible-iterator = { version = "0.2", default-features = false }
-object = { version = "0.16", default-features = false, features = ["read"], optional = true }
+object = { version = "0.17", default-features = false, features = ["read"], optional = true }
 smallvec = { version = "1", default-features = false }
 lazycell = "1"
 rustc-demangle = { version = "0.1", optional = true }
@@ -40,14 +40,20 @@ codegen-units = 1
 default = ["rustc-demangle", "cpp_demangle", "std-object"]
 std = ["gimli/std"]
 std-object = ["std", "object", "object/std"]
-alloc = ["gimli/alloc"]
 
 [[test]]
 name = "output_equivalence"
 harness = false
+required-features = ["std-object"]
 
 [[test]]
 name = "correctness"
+required-features = ["default"]
 
 [[test]]
 name = "parse"
+required-features = ["std-object"]
+
+[[example]]
+name = "addr2line"
+required-features = ["std-object"]

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -14,15 +14,11 @@ case "$GIMLI_JOB" in
         ;;
 
     "features")
+        cargo build --no-default-features
         cargo build --no-default-features --features "std"
         cargo build --no-default-features --features "std cpp_demangle"
         cargo build --no-default-features --features "std rustc-demangle"
         cargo build --no-default-features --features "std-object"
-        ;;
-
-    "nightly_features")
-        cargo build --no-default-features --features "alloc"
-        cargo build --no-default-features --features "alloc object"
         ;;
 
     "doc")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,16 +23,10 @@
 //! wrapper also uses symbol table information provided by the `object` crate.
 #![deny(missing_docs)]
 #![no_std]
-#![cfg_attr(not(feature = "std"), feature(alloc))]
 
-#[cfg(feature = "std")]
+#[allow(unused_imports)]
 #[macro_use]
-extern crate std;
-
-#[cfg(not(feature = "std"))]
 extern crate alloc;
-#[cfg(not(feature = "std"))]
-extern crate core as std;
 
 #[cfg(feature = "cpp_demangle")]
 extern crate cpp_demangle;
@@ -45,11 +39,6 @@ pub extern crate object;
 extern crate rustc_demangle;
 extern crate smallvec;
 
-#[cfg(feature = "std")]
-mod alloc {
-    pub use std::{borrow, boxed, rc, string, vec};
-}
-
 use alloc::borrow::Cow;
 use alloc::boxed::Box;
 #[cfg(feature = "object")]
@@ -57,10 +46,10 @@ use alloc::rc::Rc;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
-use std::cmp::Ordering;
-use std::iter;
-use std::mem;
-use std::u64;
+use core::cmp::Ordering;
+use core::iter;
+use core::mem;
+use core::u64;
 
 use fallible_iterator::FallibleIterator;
 use lazycell::LazyCell;
@@ -72,7 +61,7 @@ type Error = gimli::Error;
 ///
 /// Constructing a `Context` is somewhat costly, so users should aim to reuse `Context`s
 /// when performing lookups for many addresses in the same executable.
-pub struct Context<R = gimli::EndianRcSlice<gimli::RunTimeEndian>>
+pub struct Context<R>
 where
     R: gimli::Reader,
 {
@@ -81,6 +70,11 @@ where
     sections: gimli::Dwarf<R>,
 }
 
+/// The type of `Context` that supports the `new` method.
+#[cfg(feature = "std-object")]
+pub type ObjectContext = Context<gimli::EndianRcSlice<gimli::RunTimeEndian>>;
+
+#[cfg(feature = "std-object")]
 impl Context<gimli::EndianRcSlice<gimli::RunTimeEndian>> {
     /// Construct a new `Context`.
     ///
@@ -90,7 +84,6 @@ impl Context<gimli::EndianRcSlice<gimli::RunTimeEndian>> {
     ///
     /// Performance sensitive applications may want to use `Context::from_sections`
     /// with a more specialised `gimli::Reader` implementation.
-    #[cfg(feature = "object")]
     pub fn new<'data, 'file, O: object::Object<'data, 'file>>(
         file: &'file O,
     ) -> Result<Self, Error> {

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -55,7 +55,7 @@ fn parse_base_rc() {
     let target = release_fixture_path();
 
     with_file(&target, |file| {
-        addr2line::Context::new(file).unwrap();
+        addr2line::ObjectContext::new(file).unwrap();
     });
 }
 
@@ -75,7 +75,7 @@ fn parse_lines_rc() {
     let target = release_fixture_path();
 
     with_file(&target, |file| {
-        let context = addr2line::Context::new(file).unwrap();
+        let context = addr2line::ObjectContext::new(file).unwrap();
         context.parse_lines().unwrap();
     });
 }
@@ -97,7 +97,7 @@ fn parse_functions_rc() {
     let target = release_fixture_path();
 
     with_file(&target, |file| {
-        let context = addr2line::Context::new(file).unwrap();
+        let context = addr2line::ObjectContext::new(file).unwrap();
         context.parse_functions().unwrap();
     });
 }


### PR DESCRIPTION
addr2line can't do anything useful without allocating, and the alloc crate
is now stable, so having a separate alloc feature is not required.
Instead, you should simply disable all features.

Also fix `cargo test` with features disabled.

Note that the `object` feature currently requires std. This will be
relaxed in future once the following are addressed:
- the `object` crate needs updating for its `alloc` feature to work on stable
- the `stable_deref_trait` crate needs a new release for its `alloc`
feature to work on stable