### PR TITLE
Trim dependencies of `addr2line` for `backtrace`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,9 @@ travis-ci = { repository = "gimli-rs/addr2line" }
 
 [dependencies]
 gimli = { version = "0.20", default-features = false, features = ["read"] }
-fallible-iterator = { version = "0.2", default-features = false }
+fallible-iterator = { version = "0.2", default-features = false, optional = true }
 object = { version = "0.18", default-features = false, features = ["read"], optional = true }
-smallvec = { version = "1", default-features = false }
-lazycell = "1"
+smallvec = { version = "1", default-features = false, optional = true }
 rustc-demangle = { version = "0.1", optional = true }
 cpp_demangle = { version = "0.2", default-features = false, optional = true }
 
@@ -37,7 +36,7 @@ debug = true
 codegen-units = 1
 
 [features]
-default = ["rustc-demangle", "cpp_demangle", "std-object"]
+default = ["rustc-demangle", "cpp_demangle", "std-object", "fallible-iterator", "smallvec"]
 std = ["gimli/std"]
 std-object = ["std", "object", "object/std"]
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -19,6 +19,8 @@ case "$GIMLI_JOB" in
         cargo build --no-default-features --features "std cpp_demangle"
         cargo build --no-default-features --features "std rustc-demangle"
         cargo build --no-default-features --features "std-object"
+        cargo build --no-default-features --features "fallible-iterator"
+        cargo build --no-default-features --features "smallvec"
         ;;
 
     "doc")

--- a/src/lazy.rs
+++ b/src/lazy.rs
@@ -1,0 +1,29 @@
+use core::cell::UnsafeCell;
+
+pub struct LazyCell<T> {
+    contents: UnsafeCell<Option<T>>,
+}
+impl<T> LazyCell<T> {
+    pub fn new() -> LazyCell<T> {
+        LazyCell {
+            contents: UnsafeCell::new(None),
+        }
+    }
+
+    pub fn borrow_with(&self, closure: impl FnOnce() -> T) -> &T {
+        unsafe {
+            // First check if we're already initialized...
+            let ptr = self.contents.get();
+            if let Some(val) = &*ptr {
+                return val;
+            }
+            // Note that while we're executing `closure` our `borrow_with` may
+            // be called recursively. This means we need to check again after
+            // the closure has executed. For that we use the `get_or_insert`
+            // method which will only perform mutation if we aren't already
+            // `Some`.
+            let val = closure();
+            (*ptr).get_or_insert(val)
+        }
+    }
+}


### PR DESCRIPTION
This commit trims the dependencies of `addr2line` to be used in the
`backtrace` crate. The purpose here is to slowly trim down the list of
dependencies to make it easier to eventually include this in the
standard library. Fow now this handles three previously required
dependenies of `addr2line`:

* `smallvec` - this is made optional where if not present a standard
  `alloc::vec::Vec<T>` is used.
* `fallible-iterator` - this is simply made optional.
* `lazycell` - this is dropped in favor of a small hand-rolled
  implementation.

The new features are enabled by default and the thinking is that the
`backtrace` crate would disable all these features by default. If the
`std` feature of `backtrace` is activated it'd activate these features,
however.