### PR TITLE
Don't truncate ranges of units

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ clap = "2"
 backtrace = "0.3.13"
 findshlibs = "0.5"
 rustc-test = "0.3"
+aux = { path = "tests/aux" }
 
 [profile.release]
 debug = true

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -4,13 +4,8 @@ set -ex
 
 case "$GIMLI_JOB" in
     "build")
-        if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-            cargo test
-            cargo test --release
-        else
-            cargo build
-            cargo build --release
-        fi
+        cargo test
+        cargo test --release
         ;;
 
     "features")

--- a/tests/aux/Cargo.toml
+++ b/tests/aux/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "aux"
+version = "0.1.0"
+authors = []
+edition = "2018"
+publish = false

--- a/tests/aux/src/lib.rs
+++ b/tests/aux/src/lib.rs
@@ -1,0 +1,6 @@
+use std::collections::HashMap;
+pub fn foo() {
+    println!("x");
+    let mut map = HashMap::new();
+    map.insert(1, "foo");
+}

--- a/tests/correctness.rs
+++ b/tests/correctness.rs
@@ -5,15 +5,40 @@ extern crate gimli;
 extern crate memmap;
 extern crate object;
 
-use std::fs::File;
-
 use addr2line::Context;
 use findshlibs::{IterationControl, SharedLibrary, TargetSharedLibrary};
+use object::Object;
+use std::fs::File;
+
+fn find_debuginfo() -> memmap::Mmap {
+    let path = std::env::current_exe().unwrap();
+    let file = File::open(&path).unwrap();
+    let map = unsafe { memmap::Mmap::map(&file).unwrap() };
+    let file = &object::File::parse(&*map).unwrap();
+    if let Ok(uuid) = file.mach_uuid() {
+        for candidate in path.parent().unwrap().read_dir().unwrap() {
+            let path = candidate.unwrap().path();
+            if !path.to_str().unwrap().ends_with(".dSYM") {
+                continue;
+            }
+            for candidate in path.join("Contents/Resources/DWARF").read_dir().unwrap() {
+                let path = candidate.unwrap().path();
+                let file = File::open(&path).unwrap();
+                let map = unsafe { memmap::Mmap::map(&file).unwrap() };
+                let file = &object::File::parse(&*map).unwrap();
+                if file.mach_uuid().unwrap() == uuid {
+                    return map;
+                }
+            }
+        }
+    }
+
+    return map;
+}
 
 #[test]
 fn correctness() {
-    let file = File::open("/proc/self/exe").unwrap();
-    let map = unsafe { memmap::Mmap::map(&file).unwrap() };
+    let map = find_debuginfo();
     let file = &object::File::parse(&*map).unwrap();
     let ctx = Context::new(file).unwrap();
 
@@ -23,24 +48,36 @@ fn correctness() {
         IterationControl::Break
     });
 
-    let ip = (test_function as u64).wrapping_sub(bias.unwrap());
+    let test = |sym: u64, expected_prefix: &str| {
+        let ip = sym.wrapping_sub(bias.unwrap());
 
-    let mut frames = ctx.find_frames(ip).unwrap();
-    let frame = frames.next().unwrap().unwrap();
-    let name = frame.function.as_ref().unwrap().demangle().unwrap();
-    // Old rust versions generate DWARF with wrong linkage name,
-    // so only check the start.
-    if !name.starts_with("correctness::test_function") {
-        panic!("incorrect name '{}'", name);
-    }
+        let mut frames = ctx.find_frames(ip).unwrap();
+        let frame = frames.next().unwrap().unwrap();
+        let name = frame.function.as_ref().unwrap().demangle().unwrap();
+        // Old rust versions generate DWARF with wrong linkage name,
+        // so only check the start.
+        if !name.starts_with(expected_prefix) {
+            panic!("incorrect name '{}'", name);
+        }
+    };
+
+    test(test_function as u64, "correctness::test_function");
+    test(
+        small::test_function as u64,
+        "correctness::small::test_function",
+    );
+    test(aux::foo as u64, "aux::foo");
+}
+
+mod small {
+    pub fn test_function() {}
 }
 
 fn test_function() {}
 
 #[test]
 fn zero_sequence() {
-    let file = File::open("/proc/self/exe").unwrap();
-    let map = unsafe { memmap::Mmap::map(&file).unwrap() };
+    let map = find_debuginfo();
     let file = &object::File::parse(&*map).unwrap();
     let ctx = Context::new(file).unwrap();
     for probe in 0..10 {
@@ -50,8 +87,7 @@ fn zero_sequence() {
 
 #[test]
 fn zero_function() {
-    let file = File::open("/proc/self/exe").unwrap();
-    let map = unsafe { memmap::Mmap::map(&file).unwrap() };
+    let map = find_debuginfo();
     let file = &object::File::parse(&*map).unwrap();
     let ctx = Context::new(file).unwrap();
     for probe in 0..10 {

--- a/tests/output_equivalence.rs
+++ b/tests/output_equivalence.rs
@@ -136,6 +136,9 @@ fn make_tests() -> Vec<TestDescAndFn> {
 }
 
 fn main() {
+    if !cfg!(target_os = "linux") {
+        return;
+    }
     let args: Vec<_> = env::args().collect();
     test::test_main(&args, make_tests());
 }


### PR DESCRIPTION
This commit is an attempt to fix rust-lang/backtrace-rs#327. The
behavior seen there was that CGUs would often overlap each other which
would cause a previous loop which tried to ensure CGUs didn't overlap to
avoid some CGUs being candidates for symbolizing.

To fix the issue this commit removes the loop which alters the range of
each CGU. Instead CGUs are only sorted by their starting function
address. When looking up a CGU for a function the CGU's address range is
used to initially filter the sort but afterwards the units function
address table is also consulted. The first CGU which contains the
function address is what ends up getting returned.