### PR TITLE
Fix code coverage in CI

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -33,6 +33,7 @@ case "$GIMLI_JOB" in
 
     "coverage")
         RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install --force cargo-tarpaulin
+        cargo build --example addr2line
         cargo tarpaulin --verbose --ciserver travis-ci --coveralls "$TRAVIS_JOB_ID";
         ;;
 

--- a/tests/output_equivalence.rs
+++ b/tests/output_equivalence.rs
@@ -60,7 +60,9 @@ fn run_test(flags: Option<&str>) {
     let me = env::current_exe().unwrap();
     let mut exe = me.clone();
     assert!(exe.pop());
-    assert!(exe.pop());
+    if exe.file_name().unwrap().to_str().unwrap() == "deps" {
+        assert!(exe.pop());
+    }
     exe.push("examples");
     exe.push("addr2line");
 


### PR DESCRIPTION
The test executable path differs between `cargo test` and `cargo tarpaulin`.