### PR TITLE
Prepare for inclusion into libstd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,18 @@ exclude = ["/benches/*", "/fixtures/*"]
 travis-ci = { repository = "gimli-rs/addr2line" }
 
 [dependencies]
-gimli = { version = "0.21", default-features = false, features = ["read"] }
+gimli = { version = "0.22", default-features = false, features = ["read"] }
 fallible-iterator = { version = "0.2", default-features = false, optional = true }
 object = { version = "0.20", default-features = false, features = ["read"], optional = true }
 smallvec = { version = "1", default-features = false, optional = true }
 rustc-demangle = { version = "0.1", optional = true }
 cpp_demangle = { version = "0.2", default-features = false, optional = true }
+
+# Internal feature, only used when building as part of libstd, not part of the
+# stable interface of this crate.
+core = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-core' }
+alloc = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-alloc' }
+compiler_builtins = { version = '0.1.2', optional = true }
 
 [dev-dependencies]
 memmap = "0.7"
@@ -40,6 +46,10 @@ codegen-units = 1
 default = ["rustc-demangle", "cpp_demangle", "std-object", "fallible-iterator", "smallvec"]
 std = ["gimli/std"]
 std-object = ["std", "object", "object/std", "object/compression", "gimli/endian-reader"]
+
+# Internal feature, only used when building as part of libstd, not part of the
+# stable interface of this crate.
+rustc-dep-of-std = ['core', 'alloc', 'compiler_builtins', 'gimli/rustc-dep-of-std']
 
 [[test]]
 name = "output_equivalence"


### PR DESCRIPTION
This applies the same change as gimli-rs/gimli#503 to this crate.

(also see https://github.com/rust-lang/backtrace-rs/issues/328 for some context)