### PR TITLE
Improve performance by parsing function contents lazily

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -478,13 +478,11 @@ where
                             let end = row.address();
                             let mut rows = Vec::new();
                             mem::swap(&mut rows, &mut sequence_rows);
-                            if start != 0 {
-                                sequences.push(LineSequence {
-                                    start,
-                                    end,
-                                    rows: rows.into_boxed_slice(),
-                                });
-                            }
+                            sequences.push(LineSequence {
+                                start,
+                                end,
+                                rows: rows.into_boxed_slice(),
+                            });
                         }
                         continue;
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -383,7 +383,9 @@ impl<R: gimli::Reader> Context<R> {
                     let unit = &self.units[unit_id];
                     let loc = unit.find_location(probe, &self.sections)?;
                     let functions = unit.parse_functions(&self.sections, &self.units)?;
+                    // Build the list of functions that contain probe. res is ordered from outside to inside.
                     let mut res = maybe_small::Vec::new();
+                    // Starting from the outer function, walk down the path of inlined functions that contain probe.
                     let mut function_index =
                         functions.function_address_ranges[address_range_index].function;
                     loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -463,11 +463,13 @@ where
                             let end = row.address();
                             let mut rows = Vec::new();
                             mem::swap(&mut rows, &mut sequence_rows);
-                            sequences.push(LineSequence {
-                                start,
-                                end,
-                                rows: rows.into_boxed_slice(),
-                            });
+                            if start != 0 {
+                                sequences.push(LineSequence {
+                                    start,
+                                    end,
+                                    rows: rows.into_boxed_slice(),
+                                });
+                            }
                         }
                         continue;
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ use alloc::rc::Rc;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
+use core::cell::{Ref, RefCell};
 use core::cmp::Ordering;
 use core::iter;
 use core::mem;


### PR DESCRIPTION
This is a somewhat major rework of when and how functions are parsed and what representation they're stored in.

On my benchmarks, it improves overall `find_frames` performance by 1.8x to 3x, or, in absolute numbers, from 25-40 seconds to 10-20 seconds. The benchmarks in this crate are improved as well, with two caveats (see further down).

These changes are motivated by these insights:
 1. On current master, there is already one level of laziness: The functions in a unit are only parsed once we encounter an address in that unit. However, in practice, the addresses that are looked up only fall into a small subset of those functions, so we're parsing the contents of many functions unnecessarily. Moreover, this existing level of laziness is not effective in the split debug info scenario, where there's only one unit per object file to begin with.
 2. Parsing names of functions is slow. It takes up memory bandwidth, and, when the data is coming from an mmap'd file, causes more parts of the file to mapped into memory. Parsing function names should be avoided unless the name is actually needed.
 3. The vast majority of DW_TAG_subprogram instances don't cover an address range. They're functions from header files, which are repeated as DW_TAG_inlined_subroutine for the address ranges they actually end up covering in the binary. We were parsing their names unnecessarily.

This PR does the following:
 - There are now two levels of function parsing laziness.
   - The first level creates only the function ranges for "outer functions" (DW_TAG_subprogram) and writes down each outer function's dw_die_offset. By necessity, when parsing the list, we need to iterate over all abbrevs and attributes of the unit, including the ones for any nested tags for inlined functions, but we try to keep the work we do for them to a minimum.
   - The second level is done once we look up an address that falls into an outer function's address range. At that point, we parse the entries for that outer function again, starting at the recorded dw_die_offset. We parse the function name and all functions that are inlined into it, with their names and other data.
 - This two-level laziness automatically makes it so that we don't parse the names of DW_TAG_subprogram instances that don't have address ranges.
 - Reduced allocations for inline functions: For nested inline functions, we no longer have a Vec of child inlines on each inline function. Instead, we now have one Vec with all descendant inline_address_ranges on the OuterFunction.
 - We do a binary search when looking up the inline functions for an address within an outer function.

`cargo bench` results:

```
% cargo benchcmp bench-master.txt bench-better.txt
 name                                        bench-master.txt ns/iter  bench-better.txt ns/iter  diff ns/iter   diff %  speedup 
 context_new_and_query_location_rc           4,726,113                 3,377,543                   -1,348,570  -28.53%   x 1.40 
 context_new_and_query_location_slice        2,003,584                 1,542,540                     -461,044  -23.01%   x 1.30 
 context_new_and_query_with_functions_rc     4,668,415                 4,031,275                     -637,140  -13.65%   x 1.16 
 context_new_and_query_with_functions_slice  1,953,032                 1,570,379                     -382,653  -19.59%   x 1.24 
 context_new_parse_functions_rc              69,957,646                26,982,504                 -42,975,142  -61.43%   x 2.59 
 context_new_parse_functions_slice           50,998,880                20,554,205                 -30,444,675  -59.70%   x 2.48 
 context_new_parse_lines_rc                  17,311,785                17,292,187                     -19,598   -0.11%   x 1.00 
 context_new_parse_lines_slice               11,412,235                11,999,761                     587,526    5.15%   x 0.95 
 context_new_rc                              3,192,877                 3,245,348                       52,471    1.64%   x 0.98 
 context_new_slice                           1,052,836                 1,054,370                        1,534    0.15%   x 1.00 
 context_query_location_rc                   1,126,921                 1,130,779                        3,858    0.34%   x 1.00 
 context_query_location_slice                1,171,425                 1,142,100                      -29,325   -2.50%   x 1.03 
 context_query_with_functions_rc             3,856,426                 3,803,931                      -52,495   -1.36%   x 1.01 
 context_query_with_functions_slice          3,610,648                 3,452,011                     -158,637   -4.39%   x 1.05 
```

The two important improvements are the ones in `context_new_and_query_with_functions`:

```
 context_new_and_query_with_functions_rc      -13.65%   x 1.16 
 context_new_and_query_with_functions_slice   -19.59%   x 1.24 
```

Caveats:
 1. The `parse_functions` tests now have a different meaning, so their improvement is artificial. `parse_functions` longer parses all functions, it now only parses the list of outer functions.
 2. There are some tests that show worse numbers now, especially `context_new_parse_lines_slice`. This is confusing to me because I don't think I actually changed what happens in them. I think these numbers are a bit flaky and are affected by the file system cache to a large degree. I don't think I actually made anything slower.

I apologize for the size of this PR. The commits aren't the cleanest; some of them don't compile and I sometimes go back and forth between different solutions. The first commit is reverted in the last commit.
If you'd like, I can rewrite the PR as a set with more meaningfully grouped commits. Please let me know if that's necessary. Also, please feel free to make any edits you like.