### PR TITLE
Improve performance by parsing function contents lazily

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -147,6 +147,32 @@ fn context_new_parse_functions_slice(b: &mut test::Bencher) {
 }
 
 #[bench]
+fn context_new_parse_inlined_functions_rc(b: &mut test::Bencher) {
+    let target = release_fixture_path();
+
+    with_file(&target, |file| {
+        b.iter(|| {
+            let context = addr2line::Context::new(file).unwrap();
+            context.parse_inlined_functions().unwrap();
+        });
+    });
+}
+
+#[bench]
+fn context_new_parse_inlined_functions_slice(b: &mut test::Bencher) {
+    let target = release_fixture_path();
+
+    with_file(&target, |file| {
+        b.iter(|| {
+            let dwarf = dwarf_load(file);
+            let dwarf = dwarf_borrow(&dwarf);
+            let context = addr2line::Context::from_dwarf(dwarf).unwrap();
+            context.parse_inlined_functions().unwrap();
+        });
+    });
+}
+
+#[bench]
 fn context_query_location_rc(b: &mut test::Bencher) {
     let target = release_fixture_path();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -428,6 +428,15 @@ impl<R: gimli::Reader> Context<R> {
         }
         Ok(())
     }
+
+    /// Initialize all inlined function data structures. This is used for benchmarks.
+    #[doc(hidden)]
+    pub fn parse_inlined_functions(&self) -> Result<(), Error> {
+        for unit in &self.units {
+            unit.parse_functions(&self.sections, &self.units)?;
+        }
+        Ok(())
+    }
 }
 
 struct Lines {


### PR DESCRIPTION
This is a significant rebase of the great work done by @mstange in #176 . Closes #176 .

The description from that PR still applies:

>    - There are now two levels of function parsing laziness.
>        - The first level creates only the function ranges for "outer functions" (DW_TAG_subprogram) and writes down each outer function's dw_die_offset. By necessity, when parsing the list, we need to iterate over all abbrevs and attributes of the unit, including the ones for any nested tags for inlined functions, but we try to keep the work we do for them to a minimum.
>        - The second level is done once we look up an address that falls into an outer function's address range. At that point, we parse the entries for that outer function again, starting at the recorded dw_die_offset. We parse the function name and all functions that are inlined into it, with their names and other data.
>    - This two-level laziness automatically makes it so that we don't parse the names of DW_TAG_subprogram instances that don't have address ranges.
>    - Reduced allocations for inline functions: For nested inline functions, we no longer have a Vec of child inlines on each inline function. Instead, we now have one Vec with all descendant inline_address_ranges on the OuterFunction.
>    - We do a binary search when looking up the inline functions for an address within an outer function.

Differences from that PR:
- cleaner commit history
- new benchmarks
- use `LazyCell` instead of `Rc`/`RefCell`, since this makes the code easier to understand
- less factoring out of attribute parsing, since this slightly affects performance
- cosmetic changes to minimize differences to master

This PR was written by completely rewriting the commits instead of doing a normal rebase. Hopefully I haven't left out anything significant.

@mstange Could you please review this, and check against the benchmarks you were using? And thanks again for your work on this.