### PR TITLE
Don't skip entries with a zero address

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1223,18 +1223,20 @@ where
             FrameIterState::Frames(frames) => frames,
         };
 
-        let (loc, func) = match (frames.next.take(), frames.inlined_functions.next()) {
-            (None, None) => return Ok(None),
-            (loc, Some(func)) => (loc, func),
-            (Some(loc), None) => {
-                return Ok(Some(Frame {
+        let loc = frames.next.take();
+        let func = match frames.inlined_functions.next() {
+            Some(func) => func,
+            None => {
+                let frame = Frame {
                     dw_die_offset: Some(frames.function.dw_die_offset),
                     function: frames.function.name.clone().map(|name| FunctionName {
                         name,
                         language: frames.unit.lang,
                     }),
-                    location: Some(loc),
-                }))
+                    location: loc,
+                };
+                self.0 = FrameIterState::Empty;
+                return Ok(Some(frame));
             }
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,7 +231,7 @@ impl<R: gimli::Reader> Context<R> {
                     }
                 }
 
-                ranges.for_each_range(&sections, &dw_unit, true, |range| {
+                ranges.for_each_range(&sections, &dw_unit, |range| {
                     unit_ranges.push(UnitRange {
                         range,
                         unit_id,
@@ -493,13 +493,11 @@ where
                             let end = row.address();
                             let mut rows = Vec::new();
                             mem::swap(&mut rows, &mut sequence_rows);
-                            if start != 0 {
-                                sequences.push(LineSequence {
-                                    start,
-                                    end,
-                                    rows: rows.into_boxed_slice(),
-                                });
-                            }
+                            sequences.push(LineSequence {
+                                start,
+                                end,
+                                rows: rows.into_boxed_slice(),
+                            });
                         }
                         continue;
                     }
@@ -815,7 +813,7 @@ impl<R: gimli::Reader> Functions<R> {
                     }
 
                     let function_index = functions.len();
-                    if ranges.for_each_range(sections, unit, false, |range| {
+                    if ranges.for_each_range(sections, unit, |range| {
                         addresses.push(FunctionAddress {
                             range,
                             function: function_index,
@@ -1114,7 +1112,7 @@ impl<R: gimli::Reader> InlinedFunction<R> {
             call_column,
         });
 
-        ranges.for_each_range(sections, unit, false, |range| {
+        ranges.for_each_range(sections, unit, |range| {
             inlined_addresses.push(InlinedFunctionAddress {
                 range,
                 call_depth: inlined_depth,
@@ -1158,15 +1156,11 @@ impl<R: gimli::Reader> RangeAttributes<R> {
         &self,
         sections: &gimli::Dwarf<R>,
         unit: &gimli::Unit<R>,
-        allow_at_zero: bool,
         mut f: F,
     ) -> Result<bool, Error> {
         let mut added_any = false;
         let mut add_range = |range: gimli::Range| {
-            // Ignore invalid DWARF so that a query of 0 does not give
-            // a long list of matches.
-            // TODO: don't ignore if there is a section at this address
-            if (allow_at_zero || range.begin != 0) && range.begin < range.end {
+            if range.begin < range.end {
                 f(range);
                 added_any = true
             }

--- a/tests/correctness.rs
+++ b/tests/correctness.rs
@@ -81,21 +81,11 @@ fn test_function() {
 }
 
 #[test]
-fn zero_sequence() {
-    let map = find_debuginfo();
-    let file = &object::File::parse(&*map).unwrap();
-    let ctx = Context::new(file).unwrap();
-    for probe in 0..10 {
-        assert!(ctx.find_location(probe).unwrap().is_none());
-    }
-}
-
-#[test]
 fn zero_function() {
     let map = find_debuginfo();
     let file = &object::File::parse(&*map).unwrap();
     let ctx = Context::new(file).unwrap();
     for probe in 0..10 {
-        assert!(ctx.find_frames(probe).unwrap().next().unwrap().is_none());
+        assert!(ctx.find_frames(probe).unwrap().count().unwrap() < 10);
     }
 }


### PR DESCRIPTION
Also fix `FrameIter` to handle a missing location (just something I noticed when testing each of the skips individually).

Fixes #174 (cc @mstange)