### PR TITLE
Handle older DWARF versions better

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -490,8 +490,12 @@ where
                 sequences.sort_by_key(|x| x.start);
 
                 let mut files = Vec::new();
-                let mut index = 0;
                 let header = ilnp.header();
+                match header.file(0) {
+                    Some(file) => files.push(self.render_file(file, header, sections)?),
+                    None => files.push(String::from("")),  // DWARF version <= 4 may not have 0th index
+                }
+                let mut index = 1;
                 while let Some(file) = header.file(index) {
                     files.push(self.render_file(file, header, sections)?);
                     index += 1;


### PR DESCRIPTION
DWARF version <= 4 may not have index 0. As a workaround, we add a dummy
value, which should be fine since presumably 0 index should not be
referenced in any valid DWARF file <= v4. Fixes gimli-rs/addr2line#190.