### PR TITLE
quickstart: refer to re-exported object crate instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,8 @@ performed programmatically through `Context::find_location` and
 [GNU binutils](https://sourceware.org/binutils/docs/binutils/addr2line.html)).
 
 # Quickstart
-
- - Add the [`object` crate](https://crates.io/crates/object) to your `Cargo.toml`
  - Add the [`addr2line` crate](https://crates.io/crates/addr2line) to your `Cargo.toml`
- - Load the file and parse it with [`object::File::parse`](https://docs.rs/object/*/object/struct.File.html#method.parse)
+ - Load the file and parse it with [`addr2line::object::File::parse`](https://docs.rs/object/*/object/struct.File.html#method.parse)
  - Pass the parsed file to [`addr2line::Context::new` ](https://docs.rs/addr2line/*/addr2line/struct.Context.html#method.new)
  - Use [`addr2line::Context::find_location`](https://docs.rs/addr2line/*/addr2line/struct.Context.html#method.find_location)
    or [`addr2line::Context::find_frames`](https://docs.rs/addr2line/*/addr2line/struct.Context.html#method.find_frames)


### PR DESCRIPTION
#106 is hit if object and addr2line are added to Cargo.toml where object version does not match the version addr2line depends on. addr2line re-exports the correct version, which is now referred to instead.

Unfortunately, there doesn't seem to be a way to automagically link to the correct doc version for object in the quickstart.