### PR TITLE
Switch addr2line to use EndianReader.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ backtrace = "0.3.13"
 findshlibs = "0.8"
 rustc-test = "0.3"
 auxiliary = { path = "tests/auxiliary" }
+typed-arena = "2"
 
 [profile.release]
 debug = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -895,7 +895,11 @@ fn path_push(path: &mut String, p: &str) {
     if has_unix_root(p) || has_windows_root(p) {
         *path = p.to_string();
     } else {
-        let dir_separator = if has_windows_root(path.as_str()) { '\\' } else { '/' };
+        let dir_separator = if has_windows_root(path.as_str()) {
+            '\\'
+        } else {
+            '/'
+        };
 
         if !path.ends_with(dir_separator) {
             path.push(dir_separator);
@@ -911,8 +915,7 @@ fn has_unix_root(p: &str) -> bool {
 
 /// Check if the path in the given string has a windows style root
 fn has_windows_root(p: &str) -> bool {
-    p.starts_with('\\')
-    || p.get(1..3) == Some(":\\")
+    p.starts_with('\\') || p.get(1..3) == Some(":\\")
 }
 
 fn name_attr<R>(


### PR DESCRIPTION
Avoid copying the debug into RAM & instead use borrows to utilize the 0-copy facility of gimli.
Resolves #212 