### PR TITLE
Don't ignore aranges with address 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.15.1 (2021/05/02)
+
+### Fixed
+
+* Don't ignore aranges with address 0.
+  [#217](https://github.com/gimli-rs/addr2line/pull/217)
+
 ## 0.15.0 (2021/05/02)
 
 ### Breaking changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "addr2line"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>", "Philip Craig <philipjcraig@gmail.com>", "Jon Gjengset <jon@thesquareplanet.com>", "Noah Bergbauer <noah.bergbauer@tum.de>"]
 description = "A cross-platform symbolication library written in Rust, using `gimli`"
 documentation = "https://docs.rs/addr2line"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -464,10 +464,7 @@ impl<R: gimli::Reader> ResDwarf<R> {
                         let aranges_header = sections.debug_aranges.header(*aranges_offset)?;
                         let mut aranges = aranges_header.entries();
                         while let Some(arange) = aranges.next()? {
-                            // Ignore unrelocated ranges (e.g. the function was eliminated
-                            // when linking).
-                            // TODO: allow this if there is a section at address zero.
-                            if arange.address() != 0 && arange.length() != 0 {
+                            if arange.length() != 0 {
                                 unit_ranges.push(UnitRange {
                                     range: arange.range(),
                                     unit_id,


### PR DESCRIPTION
This can occur for unpacked debuginfo.