### PR TITLE
Expose endian_reader as a separate feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,9 @@ split-debuginfo = 'packed'
 
 [features]
 default = ["rustc-demangle", "cpp_demangle", "std-object", "fallible-iterator", "smallvec"]
+endian_reader = ["gimli/endian-reader"]
 std = ["gimli/std"]
-std-object = ["std", "object", "object/std", "object/compression", "gimli/endian-reader"]
+std-object = ["std", "object", "object/std", "object/compression", "endian_reader"]
 
 # Internal feature, only used when building as part of libstd, not part of the
 # stable interface of this crate.


### PR DESCRIPTION
Allows to build a Context with EndianRcSlice in no-std.
endian_reader is enabled by default on std but can't be enabled in no-std -- so building a context with EndianRcSlice results in the compiler unable to find it because it's not in the addr2line gimli version.

Maybe there is a better way to resolve this with cargo, but I'm not familiar with anything that would let me do this without patching addr2line.