### PR TITLE
Update clap to v3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ compiler_builtins = { version = '0.1.2', optional = true }
 
 [dev-dependencies]
 memmap = "0.7"
-clap = { version = "3.1.6", features = ["derive"] }
+clap = "3.1.6"
 backtrace = "0.3.13"
 findshlibs = "0.10"
 rustc-test = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ compiler_builtins = { version = '0.1.2', optional = true }
 
 [dev-dependencies]
 memmap = "0.7"
-clap = "2"
+clap = { version = "3.1.6", features = ["derive"] }
 backtrace = "0.3.13"
 findshlibs = "0.10"
 rustc-test = "0.3"

--- a/examples/addr2line.rs
+++ b/examples/addr2line.rs
@@ -96,6 +96,7 @@ fn load_file_section<'input, 'arena, Endian: gimli::Endianity>(
 }
 
 #[derive(Parser)]
+#[clap(bin_name = "hardliner")]
 #[clap(version = "0.1")]
 #[clap(about = "A fast addr2line clone")]
 struct Opts {

--- a/examples/addr2line.rs
+++ b/examples/addr2line.rs
@@ -96,7 +96,7 @@ fn load_file_section<'input, 'arena, Endian: gimli::Endianity>(
 }
 
 #[derive(Parser)]
-#[clap(bin_name = "hardliner")]
+#[clap(bin_name = "hardliner", name = "hardliner")]
 #[clap(version = "0.1")]
 #[clap(about = "A fast addr2line clone")]
 struct Opts {

--- a/examples/addr2line.rs
+++ b/examples/addr2line.rs
@@ -9,9 +9,10 @@ extern crate typed_arena;
 use std::borrow::Cow;
 use std::fs::File;
 use std::io::{BufRead, Lines, StdinLock, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::vec::IntoIter;
 
-use clap::{App, Arg, Values};
+use clap::Parser;
 use fallible_iterator::FallibleIterator;
 use object::{Object, ObjectSection};
 use typed_arena::Arena;
@@ -27,7 +28,7 @@ fn parse_uint_from_hex_string(string: &str) -> u64 {
 }
 
 enum Addrs<'a> {
-    Args(Values<'a>),
+    Args(IntoIter<String>),
     Stdin(Lines<StdinLock<'a>>),
 }
 
@@ -94,89 +95,58 @@ fn load_file_section<'input, 'arena, Endian: gimli::Endianity>(
     }
 }
 
+#[derive(Parser)]
+#[clap(version = "0.1")]
+#[clap(about = "A fast addr2line clone")]
+struct Opts {
+    /// Specify the name of the executable for which addresses should be translated.
+    #[clap(short, long, value_name = "FILENAME")]
+    exe: PathBuf,
+    /// Path to supplementary object file.
+    #[clap(long, value_name = "FILENAME")]
+    sup: Option<PathBuf>,
+    /// Display function names as well as file and line number information.
+    #[clap(short, long)]
+    functions: bool,
+    /// Make the output more human friendly: each location is printed on one line.
+    #[clap(short, long)]
+    pretty_print: bool,
+    /// If the address belongs to a function that was inlined, the source information for all
+    /// enclosing scopes back to the first non-inlined function will be printed.
+    #[clap(short, long)]
+    inlines: bool,
+    /// Display the address before the function name, file and line number information.
+    #[clap(short, long)]
+    addresses: bool,
+    /// Display only the base of each file name.
+    #[clap(short = 's', long)]
+    basenames: bool,
+    /// Demangle function names.
+    /// Specifying a specific demangling style (like GNU addr2line) is not supported. (TODO)
+    #[clap(short = 'C', long)]
+    demangle: bool,
+    /// Display output in the same format as llvm-symbolizer.
+    #[clap(long)]
+    llvm: bool,
+    /// Addresses to use instead of reading from stdin.
+    addrs: Vec<String>,
+}
+
 fn main() {
-    let matches = App::new("hardliner")
-        .version("0.1")
-        .about("A fast addr2line clone")
-        .arg(
-            Arg::with_name("exe")
-                .short("e")
-                .long("exe")
-                .value_name("filename")
-                .help(
-                    "Specify the name of the executable for which addresses should be translated.",
-                )
-                .required(true),
-        )
-        .arg(
-            Arg::with_name("sup")
-                .long("sup")
-                .value_name("filename")
-                .help("Path to supplementary object file."),
-        )
-        .arg(
-            Arg::with_name("functions")
-                .short("f")
-                .long("functions")
-                .help("Display function names as well as file and line number information."),
-        )
-        .arg(
-            Arg::with_name("pretty")
-                .short("p")
-                .long("pretty-print")
-                .help(
-                    "Make the output more human friendly: each location are printed on \
-                     one line.",
-                ),
-        )
-        .arg(Arg::with_name("inlines").short("i").long("inlines").help(
-            "If the address belongs to a function that was inlined, the source \
-             information for all enclosing scopes back to the first non-inlined \
-             function will also be printed.",
-        ))
-        .arg(
-            Arg::with_name("addresses")
-                .short("a")
-                .long("addresses")
-                .help(
-                    "Display the address before the function name, file and line \
-                     number information.",
-                ),
-        )
-        .arg(
-            Arg::with_name("basenames")
-                .short("s")
-                .long("basenames")
-                .help("Display only the base of each file name."),
-        )
-        .arg(Arg::with_name("demangle").short("C").long("demangle").help(
-            "Demangle function names. \
-             Specifying a specific demangling style (like GNU addr2line) \
-             is not supported. (TODO)",
-        ))
-        .arg(
-            Arg::with_name("llvm")
-                .long("llvm")
-                .help("Display output in the same format as llvm-symbolizer."),
-        )
-        .arg(
-            Arg::with_name("addrs")
-                .takes_value(true)
-                .multiple(true)
-                .help("Addresses to use instead of reading from stdin."),
-        )
-        .get_matches();
+    let Opts {
+        functions: do_functions,
+        inlines: do_inlines,
+        pretty_print: pretty,
+        addresses: print_addrs,
+        basenames,
+        demangle,
+        llvm,
+        exe: path,
+        sup,
+        addrs,
+    } = Opts::parse();
 
     let arena_data = Arena::new();
-
-    let do_functions = matches.is_present("functions");
-    let do_inlines = matches.is_present("inlines");
-    let pretty = matches.is_present("pretty");
-    let print_addrs = matches.is_present("addresses");
-    let basenames = matches.is_present("basenames");
-    let demangle = matches.is_present("demangle");
-    let llvm = matches.is_present("llvm");
-    let path = matches.value_of("exe").unwrap();
 
     let file = File::open(path).unwrap();
     let map = unsafe { memmap::Mmap::map(&file).unwrap() };
@@ -193,7 +163,7 @@ fn main() {
     };
 
     let sup_map;
-    let sup_object = if let Some(sup_path) = matches.value_of("sup") {
+    let sup_object = if let Some(sup_path) = sup {
         let sup_file = File::open(sup_path).unwrap();
         sup_map = unsafe { memmap::Mmap::map(&sup_file).unwrap() };
         Some(object::File::parse(&*sup_map).unwrap())
@@ -213,10 +183,11 @@ fn main() {
     let ctx = Context::from_dwarf(dwarf).unwrap();
 
     let stdin = std::io::stdin();
-    let addrs = matches
-        .values_of("addrs")
-        .map(Addrs::Args)
-        .unwrap_or_else(|| Addrs::Stdin(stdin.lock().lines()));
+    let addrs = if addrs.is_empty() {
+        Addrs::Stdin(stdin.lock().lines())
+    } else {
+        Addrs::Args(addrs.into_iter())
+    };
 
     for probe in addrs {
         if print_addrs {


### PR DESCRIPTION
This updates the `addr2line` example to `clap` v3.1.6. `clap` does have an MSRV of 1.54.0 on any v3 version, but this is unlikely to matter much in this case since it is just used as a dev dependency

The changes were pretty straightforward (and made the example more succinct), and everything seems to match the old behavior

_Just a basic test_

```
     Running `target/debug/examples/addr2line -e /tmp/a.out -f 0x1139`
main
/tmp/test.c:3
```

_Old `--help`_

```
hardliner 0.1
A fast addr2line clone

USAGE:
    addr2line [FLAGS] [OPTIONS] --exe <filename> [addrs]...

FLAGS:
    -a, --addresses       Display the address before the function name, file and line number information.
    -s, --basenames       Display only the base of each file name.
    -C, --demangle        Demangle function names. Specifying a specific demangling style (like GNU addr2line) is not
                          supported. (TODO)
    -f, --functions       Display function names as well as file and line number information.
    -h, --help            Prints help information
    -i, --inlines         If the address belongs to a function that was inlined, the source information for all
                          enclosing scopes back to the first non-inlined function will also be printed.
        --llvm            Display output in the same format as llvm-symbolizer.
    -p, --pretty-print    Make the output more human friendly: each location are printed on one line.
    -V, --version         Prints version information

OPTIONS:
    -e, --exe <filename>    Specify the name of the executable for which addresses should be translated.
        --sup <filename>    Path to supplementary object file.

ARGS:
    <addrs>...    Addresses to use instead of reading from stdin.
```

_New `--help`_

```
hardliner 0.1
A fast addr2line clone

USAGE:
    hardliner [OPTIONS] --exe <FILENAME> [ADDRS]...

ARGS:
    <ADDRS>...    Addresses to use instead of reading from stdin

OPTIONS:
    -a, --addresses         Display the address before the function name, file and line number
                            information
    -C, --demangle          Demangle function names. Specifying a specific demangling style (like
                            GNU addr2line) is not supported. (TODO)
    -e, --exe <FILENAME>    Specify the name of the executable for which addresses should be
                            translated
    -f, --functions         Display function names as well as file and line number information
    -h, --help              Print help information
    -i, --inlines           If the address belongs to a function that was inlined, the source
                            information for all enclosing scopes back to the first non-inlined
                            function will be printed
        --llvm              Display output in the same format as llvm-symbolizer
    -p, --pretty-print      Make the output more human friendly: each location is printed on one
                            line
    -s, --basenames         Display only the base of each file name
        --sup <FILENAME>    Path to supplementary object file
    -V, --version           Print version information
```