### PR TITLE
cli: Fixes and refactoring for perf support

### DIFF
--- a/examples/addr2line.rs
+++ b/examples/addr2line.rs
@@ -65,7 +65,7 @@ fn print_loc(loc: Option<&Location>, basenames: bool, llvm: bool) {
     } else if llvm {
         println!("??:0:0");
     } else {
-        println!("??:?");
+        println!("??:0");
     }
 }
 

--- a/examples/addr2line.rs
+++ b/examples/addr2line.rs
@@ -13,7 +13,7 @@ use std::path::Path;
 
 use clap::{Arg, Command, Values};
 use fallible_iterator::FallibleIterator;
-use object::{Object, ObjectSection};
+use object::{Object, ObjectSection, SymbolMap, SymbolMapName};
 use typed_arena::Arena;
 
 use addr2line::{Context, Location};
@@ -96,6 +96,10 @@ fn load_file_section<'input, 'arena, Endian: gimli::Endianity>(
         },
         None => Ok(gimli::EndianSlice::new(&[][..], endian)),
     }
+}
+
+fn find_name_from_symbols<'a>(symbols: &'a SymbolMap<SymbolMapName>, probe: u64) -> Option<&'a str> {
+    symbols.get(probe).map(|x| x.name())
 }
 
 fn main() {
@@ -229,7 +233,7 @@ fn main() {
                             demangle,
                         );
                     } else {
-                        let name = symbols.get(probe).map(|x| x.name());
+                        let name = find_name_from_symbols(&symbols, probe);
                         print_function(name, None, demangle);
                     }
 
@@ -251,7 +255,7 @@ fn main() {
 
             if !printed_anything {
                 if do_functions {
-                    let name = symbols.get(probe).map(|x| x.name());
+                    let name = find_name_from_symbols(&symbols, probe);
                     print_function(name, None, demangle);
 
                     if pretty {


### PR DESCRIPTION
#### Background

The _perf_ utility uses either _libbfd_ or _addr2line_ to obtain information about inlined symbols (the record-time unwinding itself is handled by _libunwind_). Both option uses _libbfd_ under the hood, and it seems that _libbfd_ lacks the functionality of properly constructing a binary search index before doing the mass lookups. As a result, it runs like hot garbage for a lot of debug binaries.

The option to use an out-of-process _addr2line_ was originally added for Debian linking license reasons, but it turns out that with a little tweaking we can drop in a different addr2line implementation as well. With these modifications and Gimli's addr2line dropped into /usr/local/bin, `perf report` runs magnitudes faster (~100x? didn't measure) and there doesn't appear to be major issues.

**Important**: If you want to actually try, you need to (re)build perf with the `NO_LIBBFD` option passed to make. Probably only Debian has this by default.

#### Description

perf has a few assumptions about how addr2line behaves, and here we align two behavior differences with the GNU implementation:
1. We just give a "no match" when we can't parse the input address.
2. We output `??:0` instead of `??:?` for "no match".

There are also a few refactoring so that the output code can be streamlined.