### PR TITLE
Fix output_equivalence test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
-          args: '--skip-clean --ignore-tests --out Lcov'
+          args: '--skip-clean --ignore-tests --out Lcov --implicit-test-threads'
       - name: Upload to Coveralls
         uses: coverallsapp/github-action@master
         with:

--- a/tests/output_equivalence.rs
+++ b/tests/output_equivalence.rs
@@ -11,6 +11,7 @@ use backtrace::Backtrace;
 use findshlibs::{IterationControl, SharedLibrary, TargetSharedLibrary};
 use test::{ShouldPanic, TestDesc, TestDescAndFn, TestFn, TestName};
 
+#[inline(never)]
 fn make_trace() -> Vec<String> {
     fn foo() -> Backtrace {
         bar()


### PR DESCRIPTION
rust 1.60 has started inlining more functions, so the test was reaching
addresses in the backtrace that we handle differently from
binutils addr2line. However, our handling is probably more correct
(and matches llvm), so we don't want to change to match binutils.

Fix by preventing inlining of another function.