### PR TITLE
The scope of the unsafe block can be appropriately reduced

### DIFF
--- a/src/lazy.rs
+++ b/src/lazy.rs
@@ -11,10 +11,10 @@ impl<T> LazyCell<T> {
     }
 
     pub fn borrow_with(&self, closure: impl FnOnce() -> T) -> &T {
-        unsafe {
+        
             // First check if we're already initialized...
             let ptr = self.contents.get();
-            if let Some(val) = &*ptr {
+            if let Some(val) = unsafe { &*ptr } {
                 return val;
             }
             // Note that while we're executing `closure` our `borrow_with` may
@@ -23,7 +23,7 @@ impl<T> LazyCell<T> {
             // method which will only perform mutation if we aren't already
             // `Some`.
             let val = closure();
-            (*ptr).get_or_insert(val)
-        }
+            unsafe { (*ptr).get_or_insert(val) }
+        
     }
 }

--- a/src/lazy.rs
+++ b/src/lazy.rs
@@ -11,19 +11,17 @@ impl<T> LazyCell<T> {
     }
 
     pub fn borrow_with(&self, closure: impl FnOnce() -> T) -> &T {
-        
-            // First check if we're already initialized...
-            let ptr = self.contents.get();
-            if let Some(val) = unsafe { &*ptr } {
-                return val;
-            }
-            // Note that while we're executing `closure` our `borrow_with` may
-            // be called recursively. This means we need to check again after
-            // the closure has executed. For that we use the `get_or_insert`
-            // method which will only perform mutation if we aren't already
-            // `Some`.
-            let val = closure();
-            unsafe { (*ptr).get_or_insert(val) }
-        
+        // First check if we're already initialized...
+        let ptr = self.contents.get();
+        if let Some(val) = unsafe { &*ptr } {
+            return val;
+        }
+        // Note that while we're executing `closure` our `borrow_with` may
+        // be called recursively. This means we need to check again after
+        // the closure has executed. For that we use the `get_or_insert`
+        // method which will only perform mutation if we aren't already
+        // `Some`.
+        let val = closure();
+        unsafe { (*ptr).get_or_insert(val) }
     }
 }


### PR DESCRIPTION
In this function you use the unsafe keyword for almost the entrie function body. However, I found that only 1 operation are real unsafe operation (see the list below). 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 
**Real unsafe operation list:**
1. dereferencing raw pointers (*ptr)

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 