### PR TITLE
Bump object to 0.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/gimli-rs/addr2line"
 [dependencies]
 gimli = { version = "0.26", default-features = false, features = ["read"] }
 fallible-iterator = { version = "0.2", default-features = false, optional = true }
-object = { version = "0.27.1", default-features = false, features = ["read"], optional = true }
+object = { version = "0.29", default-features = false, features = ["read"], optional = true }
 smallvec = { version = "1", default-features = false, optional = true }
 rustc-demangle = { version = "0.1", optional = true }
 cpp_demangle = { version = "0.3", default-features = false, optional = true }


### PR DESCRIPTION
In particular, picking up https://github.com/gimli-rs/object/pull/443.