### PR TITLE
Only set split-debuginfo=packed for macOS

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,6 +20,13 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
     - uses: actions/checkout@v2
+    - name: Set env (macOS)
+      if: matrix.os == 'macOS-latest'
+      run: |
+        echo "CARGO_PROFILE_DEV_SPLIT_DEBUGINFO=packed" >> $GITHUB_ENV
+        echo "CARGO_PROFILE_TEST_SPLIT_DEBUGINFO=packed" >> $GITHUB_ENV
+        echo "CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO=packed" >> $GITHUB_ENV
+        echo "CARGO_PROFILE_BENCH_SPLIT_DEBUGINFO=packed" >> $GITHUB_ENV
     - name: Install rustup
       run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile=minimal
     - name: Install rust channel

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,20 +33,12 @@ rustc-test = "0.3"
 auxiliary = { path = "tests/auxiliary" }
 typed-arena = "2"
 
-[profile.dev]
-split-debuginfo = 'packed'
-
-[profile.test]
-split-debuginfo = 'packed'
-
 [profile.release]
 debug = true
-split-debuginfo = 'packed'
 
 [profile.bench]
 debug = true
 codegen-units = 1
-split-debuginfo = 'packed'
 
 [features]
 default = ["rustc-demangle", "cpp_demangle", "std-object", "fallible-iterator", "smallvec"]


### PR DESCRIPTION
Due to changes in stability of the split-debuginfo options, we need to only set split-debuginfo=packed for macOS.

There's no target-specific cargo config setting for split-debuginfo, so we conditionally set environment variables.

Closes #256 