### PR TITLE
Support split DWARF

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install rust
-        run: rustup update 1.42.0 && rustup default 1.42.0
+        run: rustup update 1.55.0 && rustup default 1.55.0
       - name: Build
         run: cargo build
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,9 @@ readme = "./README.md"
 repository = "https://github.com/gimli-rs/addr2line"
 
 [dependencies]
-gimli = { version = "0.27.0", default-features = false, features = ["read"] }
+gimli = { version = "0.27.1", default-features = false, features = ["read"] }
 fallible-iterator = { version = "0.2", default-features = false, optional = true }
+memmap2 = { version = "0.5.5", optional = true }
 object = { version = "0.30.0", default-features = false, features = ["read"], optional = true }
 smallvec = { version = "1", default-features = false, optional = true }
 rustc-demangle = { version = "0.1", optional = true }
@@ -25,7 +26,6 @@ alloc = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-all
 compiler_builtins = { version = '0.1.2', optional = true }
 
 [dev-dependencies]
-memmap2 = "0.5.5"
 clap = "3.1.6"
 backtrace = "0.3.13"
 findshlibs = "0.10"
@@ -41,7 +41,7 @@ debug = true
 codegen-units = 1
 
 [features]
-default = ["rustc-demangle", "cpp_demangle", "std-object", "fallible-iterator", "smallvec"]
+default = ["rustc-demangle", "cpp_demangle", "std-object", "fallible-iterator", "smallvec", "memmap2"]
 std = ["gimli/std"]
 std-object = ["std", "object", "object/std", "object/compression", "gimli/endian-reader"]
 
@@ -52,7 +52,7 @@ rustc-dep-of-std = ['core', 'alloc', 'compiler_builtins', 'gimli/rustc-dep-of-st
 [[test]]
 name = "output_equivalence"
 harness = false
-required-features = ["std-object"]
+required-features = ["default"]
 
 [[test]]
 name = "correctness"
@@ -64,4 +64,4 @@ required-features = ["std-object"]
 
 [[example]]
 name = "addr2line"
-required-features = ["std-object"]
+required-features = ["default"]

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -10,6 +10,7 @@ use std::env;
 use std::fs::File;
 use std::path::{self, PathBuf};
 
+use addr2line::LookupResultExt;
 use object::{Object, ObjectSection, ObjectSymbol};
 
 fn release_fixture_path() -> PathBuf {
@@ -224,7 +225,7 @@ fn context_query_with_functions_rc(b: &mut test::Bencher) {
         let ctx = addr2line::Context::new(file).unwrap();
         // Ensure nothing is lazily loaded.
         for addr in &addresses {
-            let mut frames = ctx.find_frames(*addr).unwrap();
+            let mut frames = ctx.find_frames(*addr).skip_all_loads().unwrap();
             while let Ok(Some(ref frame)) = frames.next() {
                 test::black_box(frame);
             }
@@ -232,7 +233,7 @@ fn context_query_with_functions_rc(b: &mut test::Bencher) {
 
         b.iter(|| {
             for addr in &addresses {
-                let mut frames = ctx.find_frames(*addr).unwrap();
+                let mut frames = ctx.find_frames(*addr).skip_all_loads().unwrap();
                 while let Ok(Some(ref frame)) = frames.next() {
                     test::black_box(frame);
                 }
@@ -253,7 +254,7 @@ fn context_query_with_functions_slice(b: &mut test::Bencher) {
         let ctx = addr2line::Context::from_dwarf(dwarf).unwrap();
         // Ensure nothing is lazily loaded.
         for addr in &addresses {
-            let mut frames = ctx.find_frames(*addr).unwrap();
+            let mut frames = ctx.find_frames(*addr).skip_all_loads().unwrap();
             while let Ok(Some(ref frame)) = frames.next() {
                 test::black_box(frame);
             }
@@ -261,7 +262,7 @@ fn context_query_with_functions_slice(b: &mut test::Bencher) {
 
         b.iter(|| {
             for addr in &addresses {
-                let mut frames = ctx.find_frames(*addr).unwrap();
+                let mut frames = ctx.find_frames(*addr).skip_all_loads().unwrap();
                 while let Ok(Some(ref frame)) = frames.next() {
                     test::black_box(frame);
                 }
@@ -314,7 +315,7 @@ fn context_new_and_query_with_functions_rc(b: &mut test::Bencher) {
         b.iter(|| {
             let ctx = addr2line::Context::new(file).unwrap();
             for addr in addresses.iter().take(100) {
-                let mut frames = ctx.find_frames(*addr).unwrap();
+                let mut frames = ctx.find_frames(*addr).skip_all_loads().unwrap();
                 while let Ok(Some(ref frame)) = frames.next() {
                     test::black_box(frame);
                 }
@@ -334,7 +335,7 @@ fn context_new_and_query_with_functions_slice(b: &mut test::Bencher) {
             let dwarf = dwarf_borrow(&dwarf);
             let ctx = addr2line::Context::from_dwarf(dwarf).unwrap();
             for addr in addresses.iter().take(100) {
-                let mut frames = ctx.find_frames(*addr).unwrap();
+                let mut frames = ctx.find_frames(*addr).skip_all_loads().unwrap();
                 while let Ok(Some(ref frame)) = frames.next() {
                     test::black_box(frame);
                 }

--- a/src/builtin_split_dwarf_loader.rs
+++ b/src/builtin_split_dwarf_loader.rs
@@ -1,0 +1,155 @@
+use alloc::borrow::Cow;
+use alloc::sync::Arc;
+use std::fs::File;
+use std::path::PathBuf;
+
+use object::Object;
+
+use crate::{LookupContinuation, LookupResult};
+
+#[cfg(unix)]
+fn convert_path<R: gimli::Reader<Endian = gimli::RunTimeEndian>>(
+    r: &R,
+) -> Result<PathBuf, gimli::Error> {
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+    let bytes = r.to_slice()?;
+    let s = OsStr::from_bytes(&*bytes);
+    Ok(PathBuf::from(s))
+}
+
+fn load_section<'data: 'file, 'file, O, R, F>(
+    id: gimli::SectionId,
+    file: &'file O,
+    endian: R::Endian,
+    loader: &mut F,
+) -> Result<R, gimli::Error>
+where
+    O: object::Object<'data, 'file>,
+    R: gimli::Reader<Endian = gimli::RunTimeEndian>,
+    F: FnMut(Cow<'data, [u8]>, R::Endian) -> R,
+{
+    use object::ObjectSection;
+
+    let data = id
+        .dwo_name()
+        .and_then(|dwo_name| {
+            file.section_by_name(dwo_name)
+                .and_then(|section| section.uncompressed_data().ok())
+        })
+        .unwrap_or(Cow::Borrowed(&[]));
+    Ok(loader(data, endian))
+}
+
+/// A simple builtin split DWARF loader.
+pub struct SplitDwarfLoader<R, F>
+where
+    R: gimli::Reader<Endian = gimli::RunTimeEndian>,
+    F: FnMut(Cow<[u8]>, R::Endian) -> R,
+{
+    loader: F,
+    dwarf_package: Option<gimli::DwarfPackage<R>>,
+}
+
+impl<R, F> SplitDwarfLoader<R, F>
+where
+    R: gimli::Reader<Endian = gimli::RunTimeEndian>,
+    F: FnMut(Cow<[u8]>, R::Endian) -> R,
+{
+    fn load_dwarf_package(loader: &mut F, path: Option<PathBuf>) -> Option<gimli::DwarfPackage<R>> {
+        let mut path = path.map(Ok).unwrap_or_else(std::env::current_exe).ok()?;
+        let dwp_extension = path
+            .extension()
+            .map(|previous_extension| {
+                let mut previous_extension = previous_extension.to_os_string();
+                previous_extension.push(".dwp");
+                previous_extension
+            })
+            .unwrap_or_else(|| "dwp".into());
+        path.set_extension(dwp_extension);
+        let file = File::open(&path).ok()?;
+        let map = unsafe { memmap2::Mmap::map(&file).ok()? };
+        let dwp = object::File::parse(&*map).ok()?;
+
+        let endian = if dwp.is_little_endian() {
+            gimli::RunTimeEndian::Little
+        } else {
+            gimli::RunTimeEndian::Big
+        };
+
+        let empty = loader(Cow::Borrowed(&[]), endian);
+        gimli::DwarfPackage::load(
+            |section_id| load_section(section_id, &dwp, endian, loader),
+            empty,
+        )
+        .ok()
+    }
+
+    /// Create a new split DWARF loader.
+    pub fn new(mut loader: F, path: Option<PathBuf>) -> SplitDwarfLoader<R, F> {
+        let dwarf_package = SplitDwarfLoader::load_dwarf_package(&mut loader, path);
+        SplitDwarfLoader {
+            loader,
+            dwarf_package,
+        }
+    }
+
+    /// Run the provided `LookupResult` to completion, loading any necessary
+    /// split DWARF along the way.
+    pub fn run<L>(&mut self, mut l: LookupResult<L>) -> L::Output
+    where
+        L: LookupContinuation<Buf = R>,
+    {
+        loop {
+            let (load, continuation) = match l {
+                LookupResult::Break(output) => break output,
+                LookupResult::Continue(load) => load,
+            };
+
+            let mut r: Option<Arc<gimli::Dwarf<_>>> = None;
+            if let Some(dwp) = self.dwarf_package.as_ref() {
+                if let Ok(Some(cu)) = dwp.find_cu(load.dwo_id, &load.parent) {
+                    r = Some(Arc::new(cu));
+                }
+            }
+
+            if r.is_none() {
+                let mut path = PathBuf::new();
+                if let Some(p) = load.comp_dir.as_ref() {
+                    if let Ok(p) = convert_path(p) {
+                        path.push(p);
+                    }
+                }
+
+                if let Some(p) = load.path.as_ref() {
+                    if let Ok(p) = convert_path(p) {
+                        path.push(p);
+                    }
+                }
+
+                if let Ok(file) = File::open(&path) {
+                    if let Ok(map) = unsafe { memmap2::Mmap::map(&file) } {
+                        if let Ok(file) = object::File::parse(&*map) {
+                            let endian = if file.is_little_endian() {
+                                gimli::RunTimeEndian::Little
+                            } else {
+                                gimli::RunTimeEndian::Big
+                            };
+
+                            r = gimli::Dwarf::load(|id| {
+                                load_section(id, &file, endian, &mut self.loader)
+                            })
+                            .ok()
+                            .map(|mut dwo_dwarf| {
+                                dwo_dwarf.make_dwo(&load.parent);
+                                Arc::new(dwo_dwarf)
+                            });
+                        }
+                    }
+                }
+            }
+
+            l = continuation.resume(r);
+        }
+    }
+}

--- a/src/lazy.rs
+++ b/src/lazy.rs
@@ -10,6 +10,10 @@ impl<T> LazyCell<T> {
         }
     }
 
+    pub fn borrow(&self) -> Option<&T> {
+        unsafe { &*self.contents.get() }.as_ref()
+    }
+
     pub fn borrow_with(&self, closure: impl FnOnce() -> T) -> &T {
         // First check if we're already initialized...
         let ptr = self.contents.get();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,9 @@
 #![deny(missing_docs)]
 #![no_std]
 
+#[cfg(feature = "std")]
+extern crate std;
+
 #[allow(unused_imports)]
 #[macro_use]
 extern crate alloc;
@@ -49,8 +52,10 @@ use alloc::vec::Vec;
 
 use core::cmp::{self, Ordering};
 use core::iter;
+use core::marker::PhantomData;
 use core::mem;
 use core::num::NonZeroU64;
+use core::ops::ControlFlow;
 use core::u64;
 
 use crate::function::{Function, Functions, InlinedFunction};
@@ -67,17 +72,126 @@ mod maybe_small {
     pub type IntoIter<T> = alloc::vec::IntoIter<T>;
 }
 
+#[cfg(all(unix, feature = "std", feature = "object", feature = "memmap2"))]
+/// A simple builtin split DWARF loader.
+pub mod builtin_split_dwarf_loader;
 mod function;
 mod lazy;
 
 type Error = gimli::Error;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DebugFile {
+    Primary,
+    Supplementary,
+}
+
+/// Operations that consult debug information may require additional files
+/// to be loaded if split DWARF is being used. This enum returns the result
+/// of the operation in the `Break` variant, or information about the split
+/// DWARF that is required and a continuation to invoke once it is available
+/// in the `Continue` variant.
+///
+/// This enum is intended to be used in a loop like so:
+/// ```no_run
+///   # use addr2line::*;
+///   # use std::sync::Arc;
+///   # let ctx: Context<gimli::EndianRcSlice<gimli::RunTimeEndian>> = todo!();
+///   # let do_split_dwarf_load = |load: SplitDwarfLoad<gimli::EndianRcSlice<gimli::RunTimeEndian>>| -> Option<Arc<gimli::Dwarf<gimli::EndianRcSlice<gimli::RunTimeEndian>>>> { None };
+///   const ADDRESS: u64 = 0xdeadbeef;
+///   let mut r = ctx.find_frames(ADDRESS);
+///   let result = loop {
+///     match r {
+///       LookupResult::Break(result) => break result,
+///       LookupResult::Continue((load, continuation)) => {
+///         let dwo = do_split_dwarf_load(load);
+///         r = continuation.resume(dwo);
+///       }
+///     }
+///   };
+/// ```
+pub type LookupResult<L> = ControlFlow<
+    <L as LookupContinuation>::Output,
+    (SplitDwarfLoad<<L as LookupContinuation>::Buf>, L),
+>;
+
+/// This trait represents a partially complete operation that can be resumed
+/// once a load of needed split DWARF data is completed or abandoned by the
+/// API consumer.
+pub trait LookupContinuation: Sized {
+    /// The final output of this operation.
+    type Output;
+    /// The type of reader used.
+    type Buf: gimli::Reader;
+
+    /// Resumes the operation with the provided data.
+    ///
+    /// After the caller loads the split DWARF data required, call this
+    /// method to resume the operation. The return value of this method
+    /// indicates if the computation has completed or if further data is
+    /// required.
+    ///
+    /// If the additional data cannot be located, or the caller does not
+    /// support split DWARF, `resume(None)` can be used to continue the
+    /// operation with the data that is available.
+    fn resume(self, input: Option<Arc<gimli::Dwarf<Self::Buf>>>) -> LookupResult<Self>;
+}
+
+/// This trait is used to extend `LookupResult`.
+pub trait LookupResultExt<L: LookupContinuation> {
+    /// Callers that do not handle split DWARF can call `skip_all_loads`
+    /// to fast-forward to the end result. This result is produced with
+    /// the data that is available and may be less accurate than the
+    /// the results that would be produced if the caller did properly
+    /// support split DWARF.
+    fn skip_all_loads(self) -> L::Output;
+}
+
+impl<L: LookupContinuation> LookupResultExt<L> for LookupResult<L> {
+    fn skip_all_loads(mut self) -> L::Output {
+        loop {
+            self = match self {
+                ControlFlow::Break(t) => return t,
+                ControlFlow::Continue((_, continuation)) => continuation.resume(None),
+            };
+        }
+    }
+}
+
+trait LookupResultExtInternal<L: LookupContinuation> {
+    fn map<T, F: FnOnce(L::Output) -> T>(self, f: F) -> LookupResult<MappedLookup<T, L, F>>;
+    fn unwrap(self) -> L::Output;
+}
+
+impl<L: LookupContinuation> LookupResultExtInternal<L> for LookupResult<L> {
+    fn map<T, F: FnOnce(L::Output) -> T>(self, f: F) -> LookupResult<MappedLookup<T, L, F>> {
+        match self {
+            ControlFlow::Break(t) => ControlFlow::Break(f(t)),
+            ControlFlow::Continue((load, continuation)) => ControlFlow::Continue((
+                load,
+                MappedLookup {
+                    original: continuation,
+                    mutator: f,
+                },
+            )),
+        }
+    }
+
+    fn unwrap(self) -> L::Output {
+        match self {
+            ControlFlow::Break(t) => t,
+            ControlFlow::Continue(_) => unreachable!("Internal API misuse"),
+        }
+    }
+}
 
 /// The state necessary to perform address to line translation.
 ///
 /// Constructing a `Context` is somewhat costly, so users should aim to reuse `Context`s
 /// when performing lookups for many addresses in the same executable.
 pub struct Context<R: gimli::Reader> {
-    dwarf: ResDwarf<R>,
+    parsed_dwarf: ParsedDwarf<R>,
+    raw_dwarf: RawDwarf<R>,
 }
 
 /// The type of `Context` that supports the `new` method.
@@ -109,7 +223,7 @@ impl Context<gimli::EndianRcSlice<gimli::RunTimeEndian>> {
     /// This means it is not thread safe, has no lifetime constraints (since it copies
     /// the input data), and works for any endianity.
     ///
-    /// Performance sensitive applications may want to use `Context::from_dwarf_with_sup`
+    /// Performance sensitive applications may want to use `Context::from_dwarf`
     /// with a more specialised `gimli::Reader` implementation.
     pub fn new_with_sup<'data: 'file, 'file, O: object::Object<'data, 'file>>(
         file: &'file O,
@@ -187,18 +301,21 @@ impl<R: gimli::Reader> Context<R> {
 
     /// Construct a new `Context` from an existing [`gimli::Dwarf`] object.
     #[inline]
-    pub fn from_dwarf(sections: gimli::Dwarf<R>) -> Result<Self, Error> {
-        let mut dwarf = ResDwarf::parse(Arc::new(sections))?;
-        dwarf.sup = match dwarf.sections.sup.clone() {
-            Some(sup_sections) => Some(Box::new(ResDwarf::parse(sup_sections)?)),
-            None => None,
+    pub fn from_dwarf(sections: gimli::Dwarf<R>) -> Result<Context<R>, Error> {
+        let sup_sections = sections.sup.clone();
+        let raw_dwarf = RawDwarf {
+            sections: Arc::new(sections),
+            sup_sections,
         };
-        Ok(Context { dwarf })
-    }
-
-    /// The dwarf sections associated with this `Context`.
-    pub fn dwarf(&self) -> &gimli::Dwarf<R> {
-        &self.dwarf.sections
+        let mut parsed_dwarf = ParsedDwarf::parse(&raw_dwarf.sections)?;
+        if let Some(sup) = raw_dwarf.sup_sections.as_ref() {
+            let sup_dwarf = ParsedDwarf::parse(sup)?;
+            parsed_dwarf.sup_units = Some(sup_dwarf.units);
+        }
+        Ok(Context {
+            parsed_dwarf,
+            raw_dwarf,
+        })
     }
 
     /// Finds the CUs for the function address given.
@@ -229,7 +346,7 @@ impl<R: gimli::Reader> Context<R> {
         // First up find the position in the array which could have our function
         // address.
         let pos = match self
-            .dwarf
+            .parsed_dwarf
             .unit_ranges
             .binary_search_by_key(&probe_high, |i| i.range.begin)
         {
@@ -244,7 +361,7 @@ impl<R: gimli::Reader> Context<R> {
 
         // Once we have our index we iterate backwards from that position
         // looking for a matching CU.
-        self.dwarf.unit_ranges[..pos]
+        self.parsed_dwarf.unit_ranges[..pos]
             .iter()
             .rev()
             .take_while(move |i| {
@@ -265,25 +382,51 @@ impl<R: gimli::Reader> Context<R> {
                 if probe_low >= i.range.end || probe_high <= i.range.begin {
                     return None;
                 }
-                Some((&self.dwarf.units[i.unit_id], &i.range))
+                Some((&self.parsed_dwarf.units[i.unit_id], &i.range))
             })
     }
 
     /// Find the DWARF unit corresponding to the given virtual memory address.
-    pub fn find_dwarf_unit(&self, probe: u64) -> Option<&gimli::Unit<R>> {
-        for unit in self.find_units(probe) {
-            match unit.find_function_or_location(probe, &self.dwarf) {
-                Ok((Some(_), _)) | Ok((_, Some(_))) => return Some(&unit.dw_unit),
-                _ => {}
-            }
+    pub fn find_dwarf_and_unit(
+        &self,
+        probe: u64,
+    ) -> LookupResult<
+        impl LookupContinuation<Output = Option<(&gimli::Dwarf<R>, &gimli::Unit<R>)>, Buf = R>,
+    > {
+        let mut units_iter = self.find_units(probe);
+        if let Some(unit) = units_iter.next() {
+            return LoopingLookup::new_lookup(
+                unit.find_function_or_location(probe, self),
+                move |r| {
+                    ControlFlow::Break(match r {
+                        Ok((Some(_), _)) | Ok((_, Some(_))) => {
+                            let (dwarf, unit) = unit
+                                .dwarf_and_unit_dwo(self)
+                                // We've already been through both error cases here to get to this point.
+                                .unwrap()
+                                .unwrap();
+                            Some((&*dwarf.sections, unit))
+                        }
+                        _ => match units_iter.next() {
+                            Some(next_unit) => {
+                                return ControlFlow::Continue(
+                                    next_unit.find_function_or_location(probe, self),
+                                );
+                            }
+                            None => None,
+                        },
+                    })
+                },
+            );
         }
-        None
+
+        LoopingLookup::new_complete(None)
     }
 
     /// Find the source file and line corresponding to the given virtual memory address.
     pub fn find_location(&self, probe: u64) -> Result<Option<Location<'_>>, Error> {
         for unit in self.find_units(probe) {
-            if let Some(location) = unit.find_location(probe, &self.dwarf.sections)? {
+            if let Some(location) = unit.find_location(probe, &self.raw_dwarf.sections)? {
                 return Ok(Some(location));
             }
         }
@@ -309,33 +452,94 @@ impl<R: gimli::Reader> Context<R> {
     /// If the probe address is for an inline function then the first frame corresponds
     /// to the innermost inline function.  Subsequent frames contain the caller and call
     /// location, until an non-inline caller is reached.
-    pub fn find_frames(&self, probe: u64) -> Result<FrameIter<R>, Error> {
-        for unit in self.find_units(probe) {
-            match unit.find_function_or_location(probe, &self.dwarf)? {
-                (Some(function), location) => {
-                    let inlined_functions = function.find_inlined_functions(probe);
-                    return Ok(FrameIter(FrameIterState::Frames(FrameIterFrames {
-                        unit,
-                        sections: &self.dwarf.sections,
-                        function,
-                        inlined_functions,
-                        next: location,
-                    })));
-                }
-                (None, Some(location)) => {
-                    return Ok(FrameIter(FrameIterState::Location(Some(location))));
-                }
-                _ => {}
-            }
+    pub fn find_frames(
+        &self,
+        probe: u64,
+    ) -> LookupResult<impl LookupContinuation<Output = Result<FrameIter<R>, Error>, Buf = R>> {
+        let mut units_iter = self.find_units(probe);
+        if let Some(unit) = units_iter.next() {
+            LoopingLookup::new_lookup(unit.find_function_or_location(probe, self), move |r| {
+                ControlFlow::Break(match r {
+                    Err(e) => Err(e),
+                    Ok((Some(function), location)) => {
+                        let inlined_functions = function.find_inlined_functions(probe);
+                        Ok(FrameIter(FrameIterState::Frames(FrameIterFrames {
+                            unit,
+                            sections: &self.raw_dwarf.sections,
+                            function,
+                            inlined_functions,
+                            next: location,
+                        })))
+                    }
+                    Ok((None, Some(location))) => {
+                        Ok(FrameIter(FrameIterState::Location(Some(location))))
+                    }
+                    Ok((None, None)) => match units_iter.next() {
+                        Some(next_unit) => {
+                            return ControlFlow::Continue(
+                                next_unit.find_function_or_location(probe, self),
+                            );
+                        }
+                        None => Ok(FrameIter(FrameIterState::Empty)),
+                    },
+                })
+            })
+        } else {
+            LoopingLookup::new_complete(Ok(FrameIter(FrameIterState::Empty)))
         }
-        Ok(FrameIter(FrameIterState::Empty))
+    }
+
+    /// Preload units for `probe`.
+    ///
+    /// The iterator returns pairs of `SplitDwarfLoad`s containing the
+    /// information needed to locate and load split DWARF for `probe` and
+    /// a matching callback to invoke once that data is available.
+    ///
+    /// If this method is called, and all of the returned closures are invoked,
+    /// addr2line guarantees that any future API call for the address `probe`
+    /// will not require the loading of any split DWARF.
+    ///
+    /// ```no_run
+    ///   # use addr2line::*;
+    ///   # use std::sync::Arc;
+    ///   # let ctx: Context<gimli::EndianRcSlice<gimli::RunTimeEndian>> = todo!();
+    ///   # let do_split_dwarf_load = |load: SplitDwarfLoad<gimli::EndianRcSlice<gimli::RunTimeEndian>>| -> Option<Arc<gimli::Dwarf<gimli::EndianRcSlice<gimli::RunTimeEndian>>>> { None };
+    ///   const ADDRESS: u64 = 0xdeadbeef;
+    ///   ctx.preload_units(ADDRESS).for_each(|(load, callback)| {
+    ///     let dwo = do_split_dwarf_load(load);
+    ///     callback(dwo);
+    ///   });
+    ///
+    ///   let frames_iter = match ctx.find_frames(ADDRESS) {
+    ///     LookupResult::Break(result) => result,
+    ///     LookupResult::Continue(_) => unreachable!("addr2line promised we wouldn't get here"),
+    ///   };
+    ///
+    ///   // ...
+    /// ```
+    pub fn preload_units(
+        &'_ self,
+        probe: u64,
+    ) -> impl Iterator<
+        Item = (
+            SplitDwarfLoad<R>,
+            impl FnOnce(Option<Arc<gimli::Dwarf<R>>>) -> Result<(), gimli::Error> + '_,
+        ),
+    > {
+        self.find_units(probe)
+            .filter_map(move |unit| match unit.dwarf_and_unit_dwo(self) {
+                LookupResult::Break(_) => None,
+                LookupResult::Continue((load, continuation)) => Some((load, |result| {
+                    continuation.resume(result).unwrap().map(|_| ())
+                })),
+            })
     }
 
     /// Initialize all line data structures. This is used for benchmarks.
     #[doc(hidden)]
     pub fn parse_lines(&self) -> Result<(), Error> {
-        for unit in &self.dwarf.units {
-            unit.parse_lines(&self.dwarf.sections)?;
+        for unit in &self.parsed_dwarf.units {
+            unit.parse_lines(&self.raw_dwarf.sections)?;
         }
         Ok(())
     }
@@ -343,8 +547,8 @@ impl<R: gimli::Reader> Context<R> {
     /// Initialize all function data structures. This is used for benchmarks.
     #[doc(hidden)]
     pub fn parse_functions(&self) -> Result<(), Error> {
-        for unit in &self.dwarf.units {
-            unit.parse_functions(&self.dwarf)?;
+        for unit in &self.parsed_dwarf.units {
+            unit.parse_functions(self).skip_all_loads()?;
         }
         Ok(())
     }
@@ -352,8 +556,8 @@ impl<R: gimli::Reader> Context<R> {
     /// Initialize all inlined function data structures. This is used for benchmarks.
     #[doc(hidden)]
     pub fn parse_inlined_functions(&self) -> Result<(), Error> {
-        for unit in &self.dwarf.units {
-            unit.parse_inlined_functions(&self.dwarf)?;
+        for unit in &self.parsed_dwarf.units {
+            unit.parse_inlined_functions(self).skip_all_loads()?;
         }
         Ok(())
     }
@@ -365,15 +569,19 @@ struct UnitRange {
     range: gimli::Range,
 }
 
-struct ResDwarf<R: gimli::Reader> {
+struct ParsedDwarf<R: gimli::Reader> {
     unit_ranges: Vec<UnitRange>,
     units: Vec<ResUnit<R>>,
-    sections: Arc<gimli::Dwarf<R>>,
-    sup: Option<Box<ResDwarf<R>>>,
+    sup_units: Option<Vec<ResUnit<R>>>,
 }
 
-impl<R: gimli::Reader> ResDwarf<R> {
-    fn parse(sections: Arc<gimli::Dwarf<R>>) -> Result<Self, Error> {
+struct RawDwarf<R: gimli::Reader> {
+    sections: Arc<gimli::Dwarf<R>>,
+    sup_sections: Option<Arc<gimli::Dwarf<R>>>,
+}
+
+impl<R: gimli::Reader> ParsedDwarf<R> {
+    fn parse(sections: &gimli::Dwarf<R>) -> Result<Self, Error> {
         // Find all the references to compilation units in .debug_aranges.
         // Note that we always also iterate through all of .debug_info to
         // find compilation units, because .debug_aranges may be missing some.
@@ -484,7 +692,7 @@ impl<R: gimli::Reader> ResDwarf<R> {
                         }
                     }
                 } else {
-                    have_unit_range |= ranges.for_each_range(&sections, &dw_unit, |range| {
+                    have_unit_range |= ranges.for_each_range(sections, &dw_unit, |range| {
                         unit_ranges.push(UnitRange {
                             range,
                             unit_id,
@@ -500,7 +708,7 @@ impl<R: gimli::Reader> ResDwarf<R> {
                 // Try to get some ranges from the line program sequences.
                 if let Some(ref ilnp) = dw_unit.line_program {
                     if let Ok(lines) = lines
-                        .borrow_with(|| Lines::parse(&dw_unit, ilnp.clone(), &*sections))
+                        .borrow_with(|| Lines::parse(&dw_unit, ilnp.clone(), sections))
                         .as_ref()
                     {
                         for sequence in lines.sequences.iter() {
@@ -523,6 +731,7 @@ impl<R: gimli::Reader> ResDwarf<R> {
                 lang,
                 lines,
                 funcs: LazyCell::new(),
+                dwo: LazyCell::new(),
             });
         }
 
@@ -537,22 +746,46 @@ impl<R: gimli::Reader> ResDwarf<R> {
             i.max_end = max;
         }
 
-        Ok(ResDwarf {
+        Ok(ParsedDwarf {
             units: res_units,
             unit_ranges,
-            sections,
-            sup: None,
+            sup_units: None,
         })
     }
 
-    fn find_unit(&self, offset: gimli::DebugInfoOffset<R::Offset>) -> Result<&ResUnit<R>, Error> {
-        match self
-            .units
-            .binary_search_by_key(&offset.0, |unit| unit.offset.0)
-        {
+    fn find_unit(
+        &self,
+        offset: gimli::DebugInfoOffset<R::Offset>,
+        file: DebugFile,
+    ) -> Result<&ResUnit<R>, Error> {
+        let units = match file {
+            DebugFile::Primary => &self.units,
+            DebugFile::Supplementary => self
+                .sup_units
+                .as_ref()
+                .ok_or(gimli::Error::NoEntryAtGivenOffset)?,
+        };
+
+        match units.binary_search_by_key(&offset.0, |unit| unit.offset.0) {
             // There is never a DIE at the unit offset or before the first unit.
             Ok(_) | Err(0) => Err(gimli::Error::NoEntryAtGivenOffset),
-            Err(i) => Ok(&self.units[i - 1]),
+            Err(i) => Ok(&units[i - 1]),
+        }
+    }
+}
+
+impl<R: gimli::Reader> RawDwarf<R> {
+    fn dwo(&self, dwo_sections: Arc<gimli::Dwarf<R>>) -> RawDwarf<R> {
+        RawDwarf {
+            sections: dwo_sections,
+            sup_sections: self.sup_sections.clone(),
+        }
+    }
+
+    fn sections_for_file(&self, file: DebugFile) -> Option<&gimli::Dwarf<R>> {
+        match file {
+            DebugFile::Primary => Some(&self.sections),
+            DebugFile::Supplementary => self.sup_sections.as_deref(),
         }
     }
 }
@@ -686,10 +919,252 @@ struct ResUnit<R: gimli::Reader> {
     lang: Option<gimli::DwLang>,
     lines: LazyCell<Result<Lines, Error>>,
     funcs: LazyCell<Result<Functions<R>, Error>>,
+    dwo: LazyCell<Result<Option<Box<(RawDwarf<R>, gimli::Unit<R>)>>, Error>>,
+}
+
+/// This struct contains the information needed to find split DWARF data
+/// and to produce a `gimli::Dwarf<R>` for it.
+pub struct SplitDwarfLoad<R> {
+    /// The dwo id, for looking up in a DWARF package, or for
+    /// verifying an unpacked dwo found on the file system
+    pub dwo_id: gimli::DwoId,
+    /// The compilation directory `path` is relative to.
+    pub comp_dir: Option<R>,
+    /// A path on the filesystem, relative to `comp_dir` to find this dwo.
+    pub path: Option<R>,
+    /// Once the split DWARF data is loaded, the loader is expected
+    /// to call [make_dwo(parent)](gimli::read::Dwarf::make_dwo) before
+    /// returning the data.
+    pub parent: Arc<gimli::Dwarf<R>>,
+}
+
+struct SimpleLookup<T, R, F>
+where
+    F: FnOnce(Option<Arc<gimli::Dwarf<R>>>) -> T,
+    R: gimli::Reader,
+{
+    f: F,
+    phantom: PhantomData<(T, R)>,
+}
+
+impl<T, R, F> SimpleLookup<T, R, F>
+where
+    F: FnOnce(Option<Arc<gimli::Dwarf<R>>>) -> T,
+    R: gimli::Reader,
+{
+    fn new_complete(t: F::Output) -> LookupResult<SimpleLookup<T, R, F>> {
+        ControlFlow::Break(t)
+    }
+
+    fn new_needs_load(lookup: SplitDwarfLoad<R>, f: F) -> LookupResult<SimpleLookup<T, R, F>> {
+        ControlFlow::Continue((
+            lookup,
+            SimpleLookup {
+                f,
+                phantom: PhantomData,
+            },
+        ))
+    }
+}
+
+impl<T, R, F> LookupContinuation for SimpleLookup<T, R, F>
+where
+    F: FnOnce(Option<Arc<gimli::Dwarf<R>>>) -> T,
+    R: gimli::Reader,
+{
+    type Output = T;
+    type Buf = R;
+
+    fn resume(self, v: Option<Arc<gimli::Dwarf<Self::Buf>>>) -> LookupResult<Self> {
+        ControlFlow::Break((self.f)(v))
+    }
+}
+
+struct MappedLookup<T, L, F>
+where
+    L: LookupContinuation,
+    F: FnOnce(L::Output) -> T,
+{
+    original: L,
+    mutator: F,
+}
+
+impl<T, L, F> LookupContinuation for MappedLookup<T, L, F>
+where
+    L: LookupContinuation,
+    F: FnOnce(L::Output) -> T,
+{
+    type Output = T;
+    type Buf = L::Buf;
+
+    fn resume(self, v: Option<Arc<gimli::Dwarf<Self::Buf>>>) -> LookupResult<Self> {
+        match self.original.resume(v) {
+            ControlFlow::Break(t) => ControlFlow::Break((self.mutator)(t)),
+            ControlFlow::Continue((load, continuation)) => ControlFlow::Continue((
+                load,
+                MappedLookup {
+                    original: continuation,
+                    mutator: self.mutator,
+                },
+            )),
+        }
+    }
+}
+
+/// Some functions (e.g. `find_frames`) require considering multiple
+/// compilation units, each of which might require their own split DWARF
+/// lookup (and thus produce a continuation).
+///
+/// We store the underlying continuation here as well as a mutator function
+/// that will either a) decide that the result of this continuation is
+/// what is needed and mutate it to the final result or b) produce another
+/// `LookupResult`. `new_lookup` will in turn eagerly drive any non-continuation
+/// `LookupResult` with successive invocations of the mutator, until a new
+/// continuation or a final result is produced. And finally, the impl of
+/// `LookupContinuation::resume` will call `new_lookup` each time the
+/// computation is resumed.
+struct LoopingLookup<T, L, F>
+where
+    L: LookupContinuation,
+    F: FnMut(L::Output) -> ControlFlow<T, LookupResult<L>>,
+{
+    continuation: L,
+    mutator: F,
+}
+
+impl<T, L, F> LoopingLookup<T, L, F>
+where
+    L: LookupContinuation,
+    F: FnMut(L::Output) -> ControlFlow<T, LookupResult<L>>,
+{
+    fn new_complete(t: T) -> LookupResult<Self> {
+        ControlFlow::Break(t)
+    }
+
+    fn new_lookup(mut r: LookupResult<L>, mut mutator: F) -> LookupResult<Self> {
+        // Drive the loop eagerly so that we only ever have to represent one state
+        // (the r == ControlFlow::Continue state) in LoopingLookup.
+        let (load, continuation) = loop {
+            match r {
+                ControlFlow::Break(l) => match mutator(l) {
+                    ControlFlow::Break(t) => return ControlFlow::Break(t),
+                    ControlFlow::Continue(r2) => {
+                        r = r2;
+                    }
+                },
+                ControlFlow::Continue((load, continuation)) => break (load, continuation),
+            }
+        };
+
+        ControlFlow::Continue((
+            load,
+            LoopingLookup {
+                continuation,
+                mutator,
+            },
+        ))
+    }
+}
+
+impl<T, L, F> LookupContinuation for LoopingLookup<T, L, F>
+where
+    L: LookupContinuation,
+    F: FnMut(L::Output) -> ControlFlow<T, LookupResult<L>>,
+{
+    type Output = T;
+    type Buf = L::Buf;
+
+    fn resume(self, v: Option<Arc<gimli::Dwarf<Self::Buf>>>) -> LookupResult<Self> {
+        let r = self.continuation.resume(v);
+        LoopingLookup::new_lookup(r, self.mutator)
+    }
 }
 
 impl<R: gimli::Reader> ResUnit<R> {
+    fn dwarf_and_unit_dwo<'unit, 'ctx: 'unit>(
+        &'unit self,
+        ctx: &'ctx Context<R>,
+    ) -> LookupResult<
+        SimpleLookup<
+            Result<(&'unit RawDwarf<R>, &'unit gimli::Unit<R>), Error>,
+            R,
+            impl FnOnce(
+                Option<Arc<gimli::Dwarf<R>>>,
+            ) -> Result<(&'unit RawDwarf<R>, &'unit gimli::Unit<R>), Error>,
+        >,
+    > {
+        loop {
+            break SimpleLookup::new_complete(match self.dwo.borrow() {
+                Some(Ok(Some(v))) => Ok((&v.0, &v.1)),
+                Some(Ok(None)) => Ok((&ctx.raw_dwarf, &self.dw_unit)),
+                Some(Err(e)) => Err(*e),
+                None => {
+                    let dwo_id = match self.dw_unit.dwo_id {
+                        None => {
+                            self.dwo.borrow_with(|| Ok(None));
+                            continue;
+                        }
+                        Some(dwo_id) => dwo_id,
+                    };
+
+                    let dwo_path_f = || {
+                        let dwo_comp_dir = self.dw_unit.comp_dir.clone();
+
+                        let dwo_path = self.dw_unit.dwo_name().and_then(|s| {
+                            if let Some(s) = s {
+                                Ok(Some(ctx.raw_dwarf.sections.attr_string(&self.dw_unit, s)?))
+                            } else {
+                                Ok(None)
+                            }
+                        })?;
+                        Ok((dwo_comp_dir, dwo_path))
+                    };
+
+                    let (comp_dir, path) = match dwo_path_f() {
+                        Ok(v) => v,
+                        Err(e) => {
+                            self.dwo.borrow_with(|| Err(e));
+                            continue;
+                        }
+                    };
+
+                    let process_dwo = move |dwo_dwarf: Option<Arc<gimli::Dwarf<R>>>| {
+                        let dwo_dwarf = match dwo_dwarf {
+                            None => return Ok(None),
+                            Some(dwo_dwarf) => dwo_dwarf,
+                        };
+                        let mut dwo_units = dwo_dwarf.units();
+                        let dwo_header = match dwo_units.next()? {
+                            Some(dwo_header) => dwo_header,
+                            None => return Ok(None),
+                        };
+
+                        let mut dwo_unit = dwo_dwarf.unit(dwo_header)?;
+                        dwo_unit.copy_relocated_attributes(&self.dw_unit);
+                        Ok(Some(Box::new((ctx.raw_dwarf.dwo(dwo_dwarf), dwo_unit))))
+                    };
+
+                    return SimpleLookup::new_needs_load(
+                        SplitDwarfLoad {
+                            dwo_id,
+                            comp_dir,
+                            path,
+                            parent: ctx.raw_dwarf.sections.clone(),
+                        },
+                        move |dwo_dwarf| match self.dwo.borrow_with(|| process_dwo(dwo_dwarf)) {
+                            Ok(Some(v)) => Ok((&v.0, &v.1)),
+                            Ok(None) => Ok((&ctx.raw_dwarf, &self.dw_unit)),
+                            Err(e) => Err(*e),
+                        },
+                    );
+                }
+            });
+        }
+    }
+
     fn parse_lines(&self, sections: &gimli::Dwarf<R>) -> Result<Option<&Lines>, Error> {
+        // NB: line information is always stored in the main debug file so this does not need
+        // to handle DWOs.
         let ilnp = match self.dw_unit.line_program {
             Some(ref ilnp) => ilnp,
             None => return Ok(None),
@@ -701,19 +1176,39 @@ impl<R: gimli::Reader> ResUnit<R> {
             .map_err(Error::clone)
     }
 
-    fn parse_functions(&self, dwarf: &ResDwarf<R>) -> Result<&Functions<R>, Error> {
+    fn parse_functions_dwarf_and_unit(
+        &self,
+        unit: &gimli::Unit<R>,
+        raw_dwarf: &RawDwarf<R>,
+    ) -> Result<&Functions<R>, Error> {
         self.funcs
-            .borrow_with(|| Functions::parse(&self.dw_unit, dwarf))
+            .borrow_with(|| Functions::parse(unit, raw_dwarf))
             .as_ref()
             .map_err(Error::clone)
     }
 
-    fn parse_inlined_functions(&self, dwarf: &ResDwarf<R>) -> Result<(), Error> {
-        self.funcs
-            .borrow_with(|| Functions::parse(&self.dw_unit, dwarf))
-            .as_ref()
-            .map_err(Error::clone)?
-            .parse_inlined_functions(&self.dw_unit, dwarf)
+    fn parse_functions<'unit, 'ctx: 'unit>(
+        &'unit self,
+        ctx: &'ctx Context<R>,
+    ) -> LookupResult<impl LookupContinuation<Output = Result<&'unit Functions<R>, Error>, Buf = R>>
+    {
+        self.dwarf_and_unit_dwo(ctx).map(move |r| {
+            let (raw_dwarf, unit) = r?;
+            self.parse_functions_dwarf_and_unit(unit, raw_dwarf)
+        })
+    }
+    fn parse_inlined_functions<'unit, 'ctx: 'unit>(
+        &'unit self,
+        ctx: &'ctx Context<R>,
+    ) -> LookupResult<impl LookupContinuation<Output = Result<(), Error>, Buf = R> + 'unit> {
+        self.dwarf_and_unit_dwo(ctx).map(move |r| {
+            let (raw_dwarf, unit) = r?;
+            self.funcs
+                .borrow_with(|| Functions::parse(unit, raw_dwarf))
+                .as_ref()
+                .map_err(Error::clone)?
+                .parse_inlined_functions(unit, &ctx.parsed_dwarf, raw_dwarf)
+        })
     }
 
     fn find_location(
@@ -741,27 +1236,37 @@ impl<R: gimli::Reader> ResUnit<R> {
         LocationRangeUnitIter::new(self, sections, probe_low, probe_high)
     }
 
-    fn find_function_or_location(
-        &self,
+    fn find_function_or_location<'unit, 'ctx: 'unit>(
+        &'unit self,
         probe: u64,
-        dwarf: &ResDwarf<R>,
-    ) -> Result<(Option<&Function<R>>, Option<Location<'_>>), Error> {
-        let functions = self.parse_functions(dwarf)?;
-        let function = match functions.find_address(probe) {
-            Some(address) => {
-                let function_index = functions.addresses[address].function;
-                let (offset, ref function) = functions.functions[function_index];
-                Some(
-                    function
-                        .borrow_with(|| Function::parse(offset, &self.dw_unit, dwarf))
-                        .as_ref()
-                        .map_err(Error::clone)?,
-                )
-            }
-            None => None,
-        };
-        let location = self.find_location(probe, &dwarf.sections)?;
-        Ok((function, location))
+        ctx: &'ctx Context<R>,
+    ) -> LookupResult<
+        impl LookupContinuation<
+            Output = Result<(Option<&'unit Function<R>>, Option<Location<'unit>>), Error>,
+            Buf = R,
+        >,
+    > {
+        self.dwarf_and_unit_dwo(ctx).map(move |r| {
+            let (raw_dwarf, unit) = r?;
+            let functions = self.parse_functions_dwarf_and_unit(unit, raw_dwarf)?;
+            let function = match functions.find_address(probe) {
+                Some(address) => {
+                    let function_index = functions.addresses[address].function;
+                    let (offset, ref function) = functions.functions[function_index];
+                    Some(
+                        function
+                            .borrow_with(|| {
+                                Function::parse(offset, unit, &ctx.parsed_dwarf, raw_dwarf)
+                            })
+                            .as_ref()
+                            .map_err(Error::clone)?,
+                    )
+                }
+                None => None,
+            };
+            let location = self.find_location(probe, &raw_dwarf.sections)?;
+            Ok((function, location))
+        })
     }
 }
 
@@ -778,7 +1283,7 @@ pub struct LocationRangeIter<'ctx, R: gimli::Reader> {
 impl<'ctx, R: gimli::Reader> LocationRangeIter<'ctx, R> {
     #[inline]
     fn new(ctx: &'ctx Context<R>, probe_low: u64, probe_high: u64) -> Result<Self, Error> {
-        let sections = &ctx.dwarf.sections;
+        let sections = &ctx.raw_dwarf.sections;
         let unit_iter = ctx.find_units_range(probe_low, probe_high);
         Ok(Self {
             unit_iter: Box::new(unit_iter),
@@ -879,12 +1384,11 @@ impl<'ctx> LocationRangeUnitIter<'ctx> {
 
             let row_idx = if let Some(seq) = lines.sequences.get(seq_idx) {
                 let idx = seq.rows.binary_search_by(|row| row.address.cmp(&probe_low));
-                let idx = match idx {
+                match idx {
                     Ok(x) => x,
                     Err(0) => 0, // probe below sequence, but range could overlap
                     Err(x) => x - 1,
-                };
-                idx
+                }
             } else {
                 0
             };
@@ -906,12 +1410,7 @@ impl<'ctx> Iterator for LocationRangeUnitIter<'ctx> {
     type Item = (u64, u64, Location<'ctx>);
 
     fn next(&mut self) -> Option<(u64, u64, Location<'ctx>)> {
-        loop {
-            let seq = match self.seqs.get(self.seq_idx) {
-                Some(seq) => seq,
-                None => break,
-            };
-
+        while let Some(seq) = self.seqs.get(self.seq_idx) {
             if seq.start >= self.probe_high {
                 break;
             }


### PR DESCRIPTION
This is pretty invasive. It also depends on gimli-rs/gimli#637

To make split DWARF work, we'll ultimately need to be able to create the correct `gimli::Dwarf` and `gimli::Unit`s. The former is a blend of sections from the main (at a minimum, .debug_addr) and dwo files. The latter is parsed from the dwo and then has `copy_relocated_attributes` called with the skeleton unit from the main file.

We also don't want to force the loading of all split DWARF data up front for performance reasons.

This means we need a mechanism for lazy loading of split DWARF data (enter the new `SplitDwarfLoader` trait) that can be provided by the addr2line consumer. Once the consumer loads the correct `gimli::Dwarf` and returns it to addr2line, we can produce the correct `gimli::Unit`.

We then have to pass the correct `gimli::Dwarf` and `gimli::Unit` down into the machinery that actually does the work (largely function parsing).  To make that possible I've split (heh) `ResDwarf` into a parsed component that is append only (through the various `LazyCell`s) and a raw component which can be cheaply cloned and can have its `gimli::Dwarf` replaced when necessary. The single instance of the parsed component is passed around by reference as necessary. The raw component (along with the correct `gimli::Unit` to use) is computed by `ResUnit::dwarf_and_unit_dwo` as necessary.

A simple `SplitDwarfLoader` implementation is included in the tests. I have tested this with `-Csplit-debuginfo=unpacked` and `-Csplit-debuginfo=packed`, both with and without `-Zsplit-dwarf-kind=single`, and together with various outstanding cargo and rustc PRs I have all addr2line tests pass.