### PR TITLE
Fix handling of DW_AT_decl_file = 0.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1609,9 +1609,9 @@ where
                 None
             },
         };
-        if func.call_file != 0 {
+        if let Some(call_file) = func.call_file {
             if let Some(lines) = frames.unit.parse_lines(frames.sections)? {
-                next.file = lines.files.get(func.call_file as usize).map(String::as_str);
+                next.file = lines.files.get(call_file as usize).map(String::as_str);
             }
         }
         frames.next = Some(next);


### PR DESCRIPTION
There is a spec issue [1] with how DW_AT_call_file is specified in DWARF 5. Before, a file index of 0 would indicate no source file, however in DWARF 5 this could be a valid index into the file table.

Implementations such as LLVM generates a file index of 0 when DWARF 5 is used.

Thus, if we see a version of 5 or later, treat a file index of 0 as such.
[1]: http://wiki.dwarfstd.org/index.php?title=DWARF5_Line_Table_File_Numbers

Thanks to https://github.com/gimli-rs/gimli/pull/606 for the reference of the spec issue.