### PR TITLE
Update gimli

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "./README.md"
 repository = "https://github.com/gimli-rs/addr2line"
 
 [dependencies]
-gimli = { version = "0.27.1", default-features = false, features = ["read"] }
+gimli = { version = "0.27.2", default-features = false, features = ["read"] }
 fallible-iterator = { version = "0.2", default-features = false, optional = true }
 memmap2 = { version = "0.5.5", optional = true }
 object = { version = "0.30.0", default-features = false, features = ["read"], optional = true }


### PR DESCRIPTION
The .debug_line tombstone support is relevant to addr2line.

Closes #265 