### PR TITLE
Enable builtin_split_dwarf_loader for Windows

### DIFF
--- a/examples/addr2line.rs
+++ b/examples/addr2line.rs
@@ -210,7 +210,6 @@ fn main() {
         dwarf.load_sup(&mut load_sup_section).unwrap();
     }
 
-    #[cfg(unix)]
     let mut split_dwarf_loader = addr2line::builtin_split_dwarf_loader::SplitDwarfLoader::new(
         |data, endian| {
             gimli::EndianSlice::new(arena_data.alloc(Cow::Owned(data.into_owned())), endian)
@@ -244,10 +243,7 @@ fn main() {
             let mut printed_anything = false;
             if let Some(probe) = probe {
                 let frames = ctx.find_frames(probe);
-                #[cfg(unix)]
                 let frames = split_dwarf_loader.run(frames).unwrap();
-                #[cfg(not(unix))]
-                let frames = frames.skip_all_loads().unwrap();
                 let mut frames = frames.enumerate();
                 while let Some((i, frame)) = frames.next().unwrap() {
                     if opts.pretty && i != 0 {

--- a/src/builtin_split_dwarf_loader.rs
+++ b/src/builtin_split_dwarf_loader.rs
@@ -18,6 +18,15 @@ fn convert_path<R: gimli::Reader<Endian = gimli::RunTimeEndian>>(
     Ok(PathBuf::from(s))
 }
 
+#[cfg(not(unix))]
+fn convert_path<R: gimli::Reader<Endian = gimli::RunTimeEndian>>(
+    r: &R,
+) -> Result<PathBuf, gimli::Error> {
+    let bytes = r.to_slice()?;
+    let s = std::str::from_utf8(&bytes).map_err(|_| gimli::Error::BadUtf8)?;
+    Ok(PathBuf::from(s))
+}
+
 fn load_section<'data: 'file, 'file, O, R, F>(
     id: gimli::SectionId,
     file: &'file O,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ mod maybe_small {
     pub type IntoIter<T> = alloc::vec::IntoIter<T>;
 }
 
-#[cfg(all(unix, feature = "std", feature = "object", feature = "memmap2"))]
+#[cfg(all(feature = "std", feature = "object", feature = "memmap2"))]
 /// A simple builtin split DWARF loader.
 pub mod builtin_split_dwarf_loader;
 mod function;

--- a/tests/correctness.rs
+++ b/tests/correctness.rs
@@ -64,7 +64,6 @@ fn correctness() {
 
     let dwarf = gimli::Dwarf::load(|id| load_section(id, file, endian)).unwrap();
     let ctx = Context::from_dwarf(dwarf).unwrap();
-    #[cfg(unix)]
     let mut split_dwarf_loader = addr2line::builtin_split_dwarf_loader::SplitDwarfLoader::new(
         |data, endian| gimli::EndianArcSlice::new(Arc::from(&*data), endian),
         None,
@@ -81,10 +80,7 @@ fn correctness() {
         let ip = sym.wrapping_sub(bias.unwrap());
 
         let frames = ctx.find_frames(ip);
-        #[cfg(unix)]
         let frames = split_dwarf_loader.run(frames).unwrap();
-        #[cfg(not(unix))]
-        let frames = frames.skip_all_loads().unwrap();
         let frame = frames.last().unwrap().unwrap();
         let name = frame.function.as_ref().unwrap().demangle().unwrap();
         // Old rust versions generate DWARF with wrong linkage name,


### PR DESCRIPTION
I was unable to generate DWARF with mingw that had non-UTF8 paths. Somewhere in the toolchain the path is being lossily converted to UTF8. We may find a situation in which the DWARF doesn't contain UTF8 in the future, but until then we try to do a lossless conversion to UTF8, and return an error if that fails.