### PR TITLE
Add -l flag to specify the load address of the binary image

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ compiler_builtins = { version = '0.1.2', optional = true }
 
 [dev-dependencies]
 clap = { version = "4.3.21", features = ["wrap_help"] }
+clap-num = "1.0.2"
 backtrace = "0.3.13"
 findshlibs = "0.10"
 libtest-mimic = "0.6.1"


### PR DESCRIPTION
Add the -l flag that specifies the load address of the binary image. This changes the semantics of the addrs at the end of the command line to be the offset from this address. This allows the address on the frame to be used instead of computing the specific address by hand.