### PR TITLE
Lazy parsing cleanups

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -8,8 +8,7 @@ use crate::{Context, DebugFile, Error, RangeAttributes};
 
 pub(crate) struct Functions<R: gimli::Reader> {
     /// List of all `DW_TAG_subprogram` details in the unit.
-    #[allow(clippy::type_complexity)]
-    pub(crate) functions: Box<[(gimli::UnitOffset<R::Offset>, LazyResult<Function<R>>)]>,
+    pub(crate) functions: Box<[LazyFunction<R>]>,
     /// List of `DW_TAG_subprogram` address ranges in the unit.
     pub(crate) addresses: Box<[FunctionAddress]>,
 }
@@ -23,6 +22,33 @@ pub(crate) struct FunctionAddress {
     range: gimli::Range,
     /// An index into `Functions::functions`.
     pub(crate) function: usize,
+}
+
+pub(crate) struct LazyFunction<R: gimli::Reader> {
+    dw_die_offset: gimli::UnitOffset<R::Offset>,
+    lazy: LazyResult<Function<R>>,
+}
+
+impl<R: gimli::Reader> LazyFunction<R> {
+    fn new(dw_die_offset: gimli::UnitOffset<R::Offset>) -> Self {
+        LazyFunction {
+            dw_die_offset,
+            lazy: LazyResult::new(),
+        }
+    }
+
+    pub(crate) fn borrow(
+        &self,
+        file: DebugFile,
+        unit: &gimli::Unit<R>,
+        ctx: &Context<R>,
+        sections: &gimli::Dwarf<R>,
+    ) -> Result<&Function<R>, Error> {
+        self.lazy
+            .borrow_with(|| Function::parse(self.dw_die_offset, file, unit, ctx, sections))
+            .as_ref()
+            .map_err(Error::clone)
+    }
 }
 
 pub(crate) struct Function<R: gimli::Reader> {
@@ -106,7 +132,7 @@ impl<R: gimli::Reader> Functions<R> {
                         });
                     })?;
                     if has_address {
-                        functions.push((dw_die_offset, LazyResult::new()));
+                        functions.push(LazyFunction::new(dw_die_offset));
                     }
                 } else {
                     entries.skip_attributes(abbrev.attributes())?;
@@ -152,11 +178,7 @@ impl<R: gimli::Reader> Functions<R> {
         sections: &gimli::Dwarf<R>,
     ) -> Result<(), Error> {
         for function in &*self.functions {
-            function
-                .1
-                .borrow_with(|| Function::parse(function.0, file, unit, ctx, sections))
-                .as_ref()
-                .map_err(Error::clone)?;
+            function.borrow(file, unit, ctx, sections)?;
         }
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,7 +236,7 @@ impl<R: gimli::Reader> Context<R> {
                     ControlFlow::Break(match r {
                         Ok((Some(_), _)) | Ok((_, Some(_))) => {
                             let (_file, sections, unit) = unit
-                                .dwarf_and_unit_dwo(self)
+                                .dwarf_and_unit(self)
                                 // We've already been through both error cases here to get to this point.
                                 .unwrap()
                                 .unwrap();
@@ -363,7 +363,7 @@ impl<R: gimli::Reader> Context<R> {
     > {
         self.units
             .find(probe)
-            .filter_map(move |unit| match unit.dwarf_and_unit_dwo(self) {
+            .filter_map(move |unit| match unit.dwarf_and_unit(self) {
                 LookupResult::Output(_) => None,
                 LookupResult::Load { load, continuation } => Some((load, |result| {
                     continuation.resume(result).unwrap().map(|_| ())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ use alloc::sync::Arc;
 use core::ops::ControlFlow;
 use core::u64;
 
-use crate::function::{Function, Functions, InlinedFunction};
+use crate::function::{Function, Functions, InlinedFunction, LazyFunctions};
 use crate::line::{LineLocationRangeIter, Lines};
 use crate::lookup::{LoopingLookup, SimpleLookup};
 use crate::unit::{ResUnit, ResUnits, SupUnits};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ use core::ops::ControlFlow;
 use core::u64;
 
 use crate::function::{Function, Functions, InlinedFunction, LazyFunctions};
-use crate::line::{LineLocationRangeIter, Lines};
+use crate::line::{LazyLines, LineLocationRangeIter, Lines};
 use crate::lookup::{LoopingLookup, SimpleLookup};
 use crate::unit::{ResUnit, ResUnits, SupUnits};
 

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -199,13 +199,8 @@ impl<R: gimli::Reader> ResUnit<R> {
             let function = match functions.find_address(probe) {
                 Some(address) => {
                     let function_index = functions.addresses[address].function;
-                    let (offset, ref function) = functions.functions[function_index];
-                    Some(
-                        function
-                            .borrow_with(|| Function::parse(offset, file, unit, ctx, sections))
-                            .as_ref()
-                            .map_err(Error::clone)?,
-                    )
+                    let function = &functions.functions[function_index];
+                    Some(function.borrow(file, unit, ctx, sections)?)
                 }
                 None => None,
             };


### PR DESCRIPTION
Prompted by the clippy warnings.

`dwarf_and_unit_dwo` changes are simpler if whitespace is ignored.