### PR TITLE
Fix find_location_range

### DIFF
--- a/src/line.rs
+++ b/src/line.rs
@@ -157,8 +157,7 @@ impl<'ctx> LineLocationRangeIter<'ctx> {
         });
         let seq_idx = match seq_idx {
             Ok(x) => x,
-            Err(0) => 0, // probe below sequence, but range could overlap
-            Err(_) => lines.sequences.len(),
+            Err(x) => x, // probe below sequence, but range could overlap
         };
 
         let row_idx = if let Some(seq) = lines.sequences.get(seq_idx) {


### PR DESCRIPTION
We were failing to return location ranges when the following conditions held:
- the unit ranges differed from the sequence ranges
- there is a gap in the sequence ranges, and the probe range begins in that gap

This is unlikely to occur in practice. I reproduced the error by modifying addr2line to give every unit a single range of (0, !0).