### PR TITLE
Add --all option to addr2line binary

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ mod line;
 #[cfg(feature = "loader")]
 mod loader;
 #[cfg(feature = "loader")]
-pub use loader::Loader;
+pub use loader::{Loader, LoaderReader};
 
 mod lookup;
 pub use lookup::{LookupContinuation, LookupResult, SplitDwarfLoad};


### PR DESCRIPTION
This displays line number information for all known addresses.

#306 will improve the ordering for the output of this.