### PR TITLE
Don't include tests in package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ include = [
     "/LICENSE-MIT",
     "/README.md",
     "/src",
-    "/tests",
 ]
 
 [dependencies]


### PR DESCRIPTION
These now require the testinput submodule.