### PR TITLE
Add find_symbol_and_addr, which also returns the symbol base address

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ mod line;
 #[cfg(feature = "loader")]
 mod loader;
 #[cfg(feature = "loader")]
-pub use loader::{Loader, LoaderReader};
+pub use loader::{Loader, LoaderReader, Symbol};
 
 mod lookup;
 pub use lookup::{LookupContinuation, LookupResult, SplitDwarfLoad};

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -129,6 +129,12 @@ impl Loader {
     pub fn find_symbol(&self, probe: u64) -> Option<&str> {
         self.borrow_internal(|i, _data, _mmap| i.find_symbol(probe))
     }
+
+    /// Find the symbol table entry corresponding to the given virtual memory address.
+    /// Return the symbol name and the symbol base address.
+    pub fn find_symbol_and_addr(&self, probe: u64) -> Option<(&str, u64)> {
+        self.borrow_internal(|i, _data, _mmap| i.find_symbol_and_addr(probe))
+    }
 }
 
 struct LoaderInternal<'a> {
@@ -279,6 +285,10 @@ impl<'a> LoaderInternal<'a> {
 
     fn find_symbol(&self, probe: u64) -> Option<&str> {
         self.symbols.get(probe).map(|x| x.name())
+    }
+
+    fn find_symbol_and_addr(&self, probe: u64) -> Option<(&str, u64)> {
+        self.symbols.get(probe).map(|x| (x.name(), x.address()))
     }
 
     fn find_location(

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -44,7 +44,7 @@ pub struct Loader {
     arena_mmap: Arena<Mmap>,
 }
 
-/// Information on a symbol - its name and address
+/// Information from a symbol table entry.
 pub struct Symbol<'a> {
     /// The symbol name
     pub name: &'a str,


### PR DESCRIPTION
Hi,

I'm writing some analysis tool that uses addr2line - thanks a lot for it!

It turns out that I also need to find the symbol containing an address. `Loader.find_symbol()` gives me the name, but I also need the symbol address.

Will it be possible to add a method that also returns the address? One alternative is to return `Option<(&str, u64)>`, as what is currently in this branch, and another alternative is to return `Option<&SymbolMapName>`, both are fine with me.

Thanks!
Noam