### PR TITLE
fix: detecting windows root paths with unix-style separators

### DIFF
--- a/src/line.rs
+++ b/src/line.rs
@@ -310,5 +310,5 @@ fn has_unix_root(p: &str) -> bool {
 
 /// Check if the path in the given string has a windows style root
 fn has_windows_root(p: &str) -> bool {
-    p.starts_with('\\') || p.get(1..3) == Some(":\\")
+    p.starts_with('\\') || p.get(1..3) == Some(":\\") || p.get(1..3) == Some(":/")
 }

--- a/src/line.rs
+++ b/src/line.rs
@@ -287,10 +287,10 @@ fn render_file<R: gimli::Reader>(
 }
 
 fn path_push(path: &mut String, p: &str) {
-    if has_unix_root(p) || has_windows_root(p) {
+    if has_forward_slash_root(p) || has_backward_slash_root(p) {
         *path = p.to_string();
     } else {
-        let dir_separator = if has_windows_root(path.as_str()) {
+        let dir_separator = if has_backward_slash_root(path.as_str()) {
             '\\'
         } else {
             '/'
@@ -304,11 +304,11 @@ fn path_push(path: &mut String, p: &str) {
 }
 
 /// Check if the path in the given string has a unix style root
-fn has_unix_root(p: &str) -> bool {
-    p.starts_with('/')
+fn has_forward_slash_root(p: &str) -> bool {
+    p.starts_with('/') || p.get(1..3) == Some(":/")
 }
 
 /// Check if the path in the given string has a windows style root
-fn has_windows_root(p: &str) -> bool {
-    p.starts_with('\\') || p.get(1..3) == Some(":\\") || p.get(1..3) == Some(":/")
+fn has_backward_slash_root(p: &str) -> bool {
+    p.starts_with('\\') || p.get(1..3) == Some(":\\")
 }


### PR DESCRIPTION
On Windows Clang can produce DWARF debug information containing paths to **DW_AT_name** and **DW_AT_comp_dir** with unix-stlye slashes. for example **C:/myproject/main.cpp**. In that case case addr2line mistakenly concatenating absolute path to file with compilation directory