### PR TITLE
Add -j/--section option, to read offsets relative to section

### DIFF
--- a/src/bin/addr2line.rs
+++ b/src/bin/addr2line.rs
@@ -190,7 +190,7 @@ fn main() {
     let ctx = Loader::new_with_sup(opts.exe, opts.sup).unwrap();
 
     let section_addr = opts.section.map(|section_name| {
-        ctx.get_section_address(section_name)
+        ctx.get_section_address(section_name.as_bytes())
             .unwrap_or_else(|| panic!("cannot find section {}", section_name))
     });
 

--- a/src/bin/addr2line.rs
+++ b/src/bin/addr2line.rs
@@ -223,16 +223,16 @@ fn main() {
         }
 
         // If --section is given, add the section address to probe.
-        let probe = probe.map(|probe| {
+        let probe = probe.and_then(|probe| {
             if let Some(section_range) = section_range {
                 if probe < (section_range.end - section_range.begin) {
-                    probe + section_range.begin
+                    Some(probe + section_range.begin)
                 } else {
                     // If addr >= section size, treat it as if no line number information was found.
-                    0
+                    None
                 }
             } else {
-                probe
+                Some(probe)
             }
         });
 

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -145,8 +145,8 @@ impl Loader {
     }
 
     /// Get the address of a section
-    pub fn get_section_address(&self, section_name: &[u8]) -> Option<u64> {
-        self.borrow_internal(|i, _data, _mmap| i.get_section_address(section_name))
+    pub fn get_section_range(&self, section_name: &[u8]) -> Option<gimli::Range> {
+        self.borrow_internal(|i, _data, _mmap| i.get_section_range(section_name))
     }
 }
 
@@ -307,10 +307,14 @@ impl<'a> LoaderInternal<'a> {
         })
     }
 
-    fn get_section_address(&self, section_name: &[u8]) -> Option<u64> {
+    fn get_section_range(&self, section_name: &[u8]) -> Option<gimli::Range> {
         self.object
             .section_by_name_bytes(section_name)
-            .map(|section| section.address())
+            .map(|section| {
+                let begin = section.address();
+                let end = begin + section.size();
+                gimli::Range { begin, end }
+            })
     }
 
     fn find_location(

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -227,8 +227,9 @@ impl<'a> LoaderInternal<'a> {
         } else {
             gimli::RunTimeEndian::Big
         };
-        let mut dwarf =
-            gimli::Dwarf::load(|id| load_section(Some(id.name()), dwarf_object, endian, arena_data))?;
+        let mut dwarf = gimli::Dwarf::load(|id| {
+            load_section(Some(id.name()), dwarf_object, endian, arena_data)
+        })?;
         if let Some(sup_object) = &sup_object {
             dwarf.load_sup(|id| load_section(Some(id.name()), sup_object, endian, arena_data))?;
         }

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -145,7 +145,7 @@ impl Loader {
     }
 
     /// Get the address of a section
-    pub fn get_section_address(&self, section_name: &str) -> Option<u64> {
+    pub fn get_section_address(&self, section_name: &[u8]) -> Option<u64> {
         self.borrow_internal(|i, _data, _mmap| i.get_section_address(section_name))
     }
 }
@@ -307,9 +307,9 @@ impl<'a> LoaderInternal<'a> {
         })
     }
 
-    fn get_section_address(&self, section_name: &str) -> Option<u64> {
+    fn get_section_address(&self, section_name: &[u8]) -> Option<u64> {
         self.object
-            .section_by_name(section_name)
+            .section_by_name_bytes(section_name)
             .map(|section| section.address())
     }
 

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -219,16 +219,16 @@ impl<'a> LoaderInternal<'a> {
         } else {
             None
         };
-        let object1 = dsym.as_ref().unwrap_or(&object);
+        let dwarf_object = dsym.as_ref().unwrap_or(&object);
 
         // Load the DWARF sections.
-        let endian = if object1.is_little_endian() {
+        let endian = if dwarf_object.is_little_endian() {
             gimli::RunTimeEndian::Little
         } else {
             gimli::RunTimeEndian::Big
         };
         let mut dwarf =
-            gimli::Dwarf::load(|id| load_section(Some(id.name()), object1, endian, arena_data))?;
+            gimli::Dwarf::load(|id| load_section(Some(id.name()), dwarf_object, endian, arena_data))?;
         if let Some(sup_object) = &sup_object {
             dwarf.load_sup(|id| load_section(Some(id.name()), sup_object, endian, arena_data))?;
         }


### PR DESCRIPTION
I suggested to my coworker to use the Rust addr2line instead of the binutils, since it took a long time using the binutils version. However, he was using the `-j/--section` option of binutils addr2line, which wasn't implemented. So I implemented it. It just requires adding the section address before doing the lookup.

What do you think?