### PR TITLE
Remove `compiler-builtins` from `rustc-dep-of-std` dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,6 @@ dependencies = [
  "auxiliary",
  "backtrace",
  "clap",
- "compiler_builtins",
  "cpp_demangle",
  "criterion",
  "fallible-iterator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ clap = { version = "4.3.21", features = ["wrap_help"], optional = true }
 # stable interface of this crate.
 core = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-core' }
 alloc = { version = '1.0.0', optional = true, package = 'rustc-std-workspace-alloc' }
-compiler_builtins = { version = '0.1.2', optional = true }
 
 [dev-dependencies]
 backtrace = "0.3.13"
@@ -68,7 +67,7 @@ cargo-all = []
 
 # Internal feature, only used when building as part of libstd, not part of the
 # stable interface of this crate.
-rustc-dep-of-std = ['core', 'alloc', 'compiler_builtins', 'gimli/rustc-dep-of-std']
+rustc-dep-of-std = ['core', 'alloc', 'gimli/rustc-dep-of-std']
 
 [[test]]
 name = "testinput"


### PR DESCRIPTION
Since [1], this will come automatically from `rustc-std-workspace-core` and the crates.io dependency should no longer be specified.

[1]: https://github.com/rust-lang/rust/pull/141993