### PR TITLE
Use unstable instead of stable sorts

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -158,7 +158,7 @@ impl<R: gimli::Reader> Functions<R> {
         // It's possible for multiple functions to have the same address range if the
         // compiler can detect and remove functions with identical code.  In that case
         // we'll nondeterministically return one of them.
-        addresses.sort_by_key(|x| x.range.begin);
+        addresses.sort_unstable_by_key(|x| x.range.begin);
 
         Ok(Functions {
             functions: functions.into_boxed_slice(),
@@ -252,7 +252,7 @@ impl<R: gimli::Reader> Function<R> {
         // In this example, if you want to look up address 7 at depth 0, and you
         // encounter [0..2 at depth 1], are you before or after the target range?
         // You don't know.
-        state.addresses.sort_by(|r1, r2| {
+        state.addresses.sort_unstable_by(|r1, r2| {
             if r1.call_depth < r2.call_depth {
                 Ordering::Less
             } else if r1.call_depth > r2.call_depth {

--- a/src/line.rs
+++ b/src/line.rs
@@ -94,7 +94,7 @@ impl Lines {
                 column,
             });
         }
-        sequences.sort_by_key(|x| x.start);
+        sequences.sort_unstable_by_key(|x| x.start);
 
         let mut files = Vec::new();
         let header = rows.header();

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -362,7 +362,7 @@ impl<R: gimli::Reader> ResUnits<R> {
         }
 
         // Sort this for faster lookup in `Self::find_range`.
-        unit_ranges.sort_unstable_by_key(|i| i.range.end);
+        unit_ranges.sort_unstable_by_key(|i| (i.range.end, i.unit_id));
 
         // Calculate the `min_begin` field now that we've determined the order of
         // CUs.

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -208,7 +208,7 @@ impl<R: gimli::Reader> ResUnits<R> {
         while let Some(header) = headers.next()? {
             aranges.push((header.debug_info_offset(), header.offset()));
         }
-        aranges.sort_by_key(|i| i.0);
+        aranges.sort_unstable_by_key(|i| i.0);
 
         let mut unit_ranges = Vec::new();
         let mut res_units = Vec::new();
@@ -362,7 +362,7 @@ impl<R: gimli::Reader> ResUnits<R> {
         }
 
         // Sort this for faster lookup in `Self::find_range`.
-        unit_ranges.sort_by_key(|i| i.range.end);
+        unit_ranges.sort_unstable_by_key(|i| i.range.end);
 
         // Calculate the `min_begin` field now that we've determined the order of
         // CUs.


### PR DESCRIPTION
Unstable sorting has significantly better code size (and often better performance too). With this change (rebased on top of v0.25.0, which is what std currently uses) the .text size of Rust hello world (with `-Clto=fat -Copt-level=s`) goes from 297120 to 290351 (-2.23%).

I do not know *that* much about addr2line, so I cannot guarantee that this code is fine with unstable sorting. But I think it should be fine since it always sorts on addresses, which are either unique or nondeterministic anyways (as mentioned in one comment even). So it should not make a significant difference.