### PR TITLE
Ignore empty line sequences

### DIFF
--- a/src/line.rs
+++ b/src/line.rs
@@ -58,11 +58,13 @@ impl Lines {
                     let end = row.address();
                     let mut rows = Vec::new();
                     mem::swap(&mut rows, &mut sequence_rows);
-                    sequences.push(LineSequence {
-                        start,
-                        end,
-                        rows: rows.into_boxed_slice(),
-                    });
+                    if start < end {
+                        sequences.push(LineSequence {
+                            start,
+                            end,
+                            rows: rows.into_boxed_slice(),
+                        });
+                    }
                 }
                 continue;
             }


### PR DESCRIPTION
This doesn't matter for `Lines::find_location`, but it does matter for `Lines::find_location_range`, because we might sort the sequences so that the empty sequence comes later, and start the iteration at the empty sequence.

Noticed in #358 